### PR TITLE
Create route for Yoast premium deprecations page

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -168,6 +168,7 @@ module.exports = {
 					type: 'category',
 					label: 'Yoast SEO Premium',
 					items: [
+						'customization/yoast-seo-premium/api-filter-actions-deprecations',
 						'customization/yoast-seo-premium/disabling-automatic-redirects-notifications',
 						'customization/yoast-seo-premium/hiding-version-number',
 					],


### PR DESCRIPTION
Route for Yoast SEO premium deprecation page.
Requires https://github.com/Yoast/developer-docs/pull/139.