### PR TITLE
Move the piece specific Schema API docs to the pieces page

### DIFF
--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -105,6 +105,7 @@ If you want to change the output of a certain piece, hook into our `wpseo_schema
 
 * [Article](pieces/article.md#api)
 * [Breadcrumb](pieces/breadcrumb.md#api)
+* [Organization](pieces/organization.md#api)
 * [Webpage](pieces/webpage.md#api)
 * [Website](pieces/website.md#api)
 

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -65,6 +65,18 @@ function remove_breadcrumbs_property_from_webpage( $data ) {
 }
 ```
 
+#### Enable / disabling graph pieces by filter
+Sometimes you might want to enable or disable a graph piece based on other variables then the graph piece itself can determine. For instance, you might always want to show a Person on your site. You can do this by hooking into the `wpseo_schema_needs_<class-name>` filter. In this particular case, the code would look like this:
+
+```php
+add_filter( 'wpseo_schema_needs_person', '__return_true' );
+add_filter( 'wpseo_schema_person_user_id', function() {
+    return 1; // Make sure 1 is a valid User ID.
+} );
+```
+
+It really is as simple as returning true on that to always show it, but you can of course also hook a function there with more precise logic. The second filter is needed to provide a user ID that should be used for the Person to show, as otherwise it won't work as the code doesn't know which user to show.
+
 ### Adding graph pieces
 Each of our graph pieces extend a `Abstract_Schema_Piece` class. We pass a `Meta_Tags_Context` object to each of these pieces, which contains a lot of context variables. A good example of that can be found in our [example use case](integration-guidelines.md#an-example-use-case), and deeper examples can be found [here on Github](https://github.com/Yoast/wordpress-seo/blob/trunk/src/generators/schema/author.php).
 
@@ -107,9 +119,9 @@ If you want to change the output of a certain piece, hook into our `wpseo_schema
 * [Breadcrumb](pieces/breadcrumb.md#api)
 * [Organization](pieces/organization.md#api)
 * [Person](pieces/person.md#api)
+* [SearchAction](pieces/searchaction.md#api)
 * [Webpage](pieces/webpage.md#api)
 * [Website](pieces/website.md#api)
-
 
 ## Perform complex changes to the whole Schema
 If you need to perform complex operations to the Schema, such as changing values in different parts of the output, you can hook into our `wpseo_schema_graph` filter. For instance:
@@ -196,42 +208,3 @@ public function render_joost_block_schema( $graph, $block, $context ) {
 	return $graph;
 }
 ```
-
-## More specific filters
-
-### Enable / disabling graph pieces by filter
-Sometimes you might want to enable or disable a graph piece based on other variables then the graph piece itself can determine. For instance, you might always want to show a Person on your site. You can do this by hooking into the `wpseo_schema_needs_<class-name>` filter. In this particular case, the code would look like this:
-
-```php
-add_filter( 'wpseo_schema_needs_person', '__return_true' );
-add_filter( 'wpseo_schema_person_user_id', function() {
-    return 1; // Make sure 1 is a valid User ID.
-} );
-```
-
-It really is as simple as returning true on that to always show it, but you can of course also hook a function there with more precise logic. The second filter is needed to provide a user ID that should be used for the Person to show, as otherwise it won't work as the code doesn't know which user to show.
-
-### Social profiles
-If you want to change which profiles to show on an author page, you can hook into our `wpseo_schema_person_social_profiles` filter. We do this on yoast.com to add people's GitHub and WordPress profile as well as their personal sites to their sameAs output:
-
-```php
-add_filter( 'wpseo_schema_person_social_profiles', 'yoast_add_social_profiles' );
-
-/**
- * Adds social profiles to our sameAs array.
- *
- * @param array $profiles Social profiles.
- *
- * @return array Social profiles.
- */
-function yoast_add_social_profiles( $profiles ) {
-    array_push( $profiles, 'github', 'personal', 'wordpress' );
-
-    return $profiles;
-}
-```
-
-### Other filters
-We also have some more specific filters for convenience:
-* `disable_wpseo_json_ld_search` - disables the search potentialAction that we add on every page if you simply return true on it.
-* `wpseo_json_ld_search_url` - allows you to change the search URL for your site.

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -106,6 +106,7 @@ If you want to change the output of a certain piece, hook into our `wpseo_schema
 * [Article](pieces/article.md#api)
 * [Breadcrumb](pieces/breadcrumb.md#api)
 * [Organization](pieces/organization.md#api)
+* [Person](pieces/person.md#api)
 * [Webpage](pieces/webpage.md#api)
 * [Website](pieces/website.md#api)
 
@@ -234,4 +235,3 @@ function yoast_add_social_profiles( $profiles ) {
 We also have some more specific filters for convenience:
 * `disable_wpseo_json_ld_search` - disables the search potentialAction that we add on every page if you simply return true on it.
 * `wpseo_json_ld_search_url` - allows you to change the search URL for your site.
-* `wpseo_schema_person_user_id` - allows changing the ID of the user we use to represent your site, should your site represent a person.

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -103,46 +103,11 @@ $data['organization'] = [ '@id' => Schema_IDs::ORGANIZATION_HASH ];
 ## Change a graph pieces' data
 If you want to change the output of a certain piece, hook into our `wpseo_schema_<class>` filter. For instance:
 
-```php
-add_filter( 'wpseo_schema_article', 'change_article_to_social_posting' );
+* [Article](pieces/article.md#api)
+* [Breadcrumb](pieces/breadcrumb.md#api)
+* [Webpage](pieces/webpage.md#api)
+* [Website](pieces/website.md#api)
 
-/**
- * Changes @type of Article Schema data.
- *
- * @param array $data Schema.org Article data array.
- *
- * @return array Schema.org Article data array.
- */
-function change_article_to_social_posting( $data ) {
-    $data['@type'] = 'SocialMediaPosting';
-
-    return $data;
-}
-```
-
-In most cases, you're probably going to want to include some conditional logic to determine where and when you change or
-set your own values. In those cases, you can use standard WordPress filtering and functions, like so:
-
-```php
-add_filter( 'wpseo_schema_webpage', 'example_change_webpage' );
-
-/**
- * Changes @type of Webpage Schema data.
- *
- * @param array $data Schema.org Webpage data array.
- *
- * @return array Schema.org Webpage data array.
- */
-function example_change_webpage( $data ) {
-    if ( ! is_page( 'about' ) ) {
-        return $data;
-    }
-
-    $data['@type'] = 'AboutPage';
-
-    return $data;
-}
-```
 
 ## Perform complex changes to the whole Schema
 If you need to perform complex operations to the Schema, such as changing values in different parts of the output, you can hook into our `wpseo_schema_graph` filter. For instance:
@@ -165,61 +130,6 @@ function change_image_urls_to_cdn( $data, $context ) {
         }
     }
     return $data;
-}
-```
-
-## To add images to your Schema
-If you want to add an image to an object programmatically, you can do it as follows. Note that we use the `YoastSEO`
-surface to get both the `canonical` from the `meta` surface as the `helpers` surface to access the `schema->image`
-functionality.
-
-```php
-add_filter( 'wpseo_schema_article', 'example_change_article' );
-
-/**
- * Adds images to Article Schema data.
- *
- * @param array $data Schema.org Article data array.
- *
- * @return array Schema.org Article data array.
- */
-function example_change_article( $data ) {
-    // This is the attachment ID for our image.
-    $attachment_id = 12345;
-
-    // We're going to create a graph piece for our image. Every graph piece always needs a Schema ID, so it can
-    // be referenced by other graph pieces, best practice is to base that on the canonical adding an ID that's
-    // always going to be unique.
-    $schema_id     = YoastSEO()->meta->for_current_page()->canonical . '#/schema/image/' . $attachment_id;                 
-    $data['image'] = new WPSEO_Schema_Image( $schema_id );
-
-    return $data;
-}
-```
-
-Instead of `YoastSEO()->helpers->schema->image->generate_from_attachment_id()` you can also use
-`YoastSEO()->helpers->schema->image->generate_from_url()` which takes, as you've guessed, a URL as input.
-
-## Replace domain name in the breadcrumb schema
-If you want to replace the domain name in the breadcrumb schema, you can use the `wpseo_schema_breadcrumb` filter to hook into the breadcrumb schema piece individually.
-
-```php
-add_filter('wpseo_schema_breadcrumb', 'replace_domain_name_to_breadcrumb_schema', 11, 2);
-/**
- * Replace domain name in the breadcrumb schema piece individually.
- * 
- * @param array $piece Schema.org Breadcrumb data array.
- * 
- * @return array Altered Schema.org Breadcrumb data array.
- */
-function replace_domain_name_to_breadcrumb_schema( $piece ) {
-    $piece['@id'] = str_replace( 'olddomain.tld', 'newdomain.tld', $piece['@id'] );
-    foreach ( $piece['itemListElement'] as &$list ) {
-        if ( $list['item'] ) {
-            $list['item'] = str_replace( 'olddomain.tld', 'newdomain.tld', $list['item'] );
-        }
-    }
-    return $piece;
 }
 ```
 
@@ -319,36 +229,8 @@ function yoast_add_social_profiles( $profiles ) {
 }
 ```
 
-### Output Article schema on custom post types
-By default Yoast SEO doesn't output Article schema on custom post types. The code below changes that:
-
-```php
-/**
- * Add 'book' to the list of articles post types, so books get Article schema.
- *
- * @param  mixed $post_types The current list of post types.
- *
- * @return array Array of post types for which Yoast SEO renders Article schema.
- */
-function article_schema_for_books( $post_types ) {
-	$post_types[] = 'book';
-	return $post_types;
-}
-
-add_filter( 'wpseo_schema_article_post_types', 'article_schema_for_books' );
-```
-
-Note that for a post type to be able to output Article schema, the post type needs to support having an Author. You can add that simply by adding this, for a given post type `book`:
-
-```php
-add_post_type_support( 'book', 'author' );
-```
-
-This currently does not work for the `page` post type. We are fixing this.
-
 ### Other filters
 We also have some more specific filters for convenience:
-* `wpseo_schema_webpage_type` - changes the page type, so could be used to make the above example even simpler.
 * `disable_wpseo_json_ld_search` - disables the search potentialAction that we add on every page if you simply return true on it.
 * `wpseo_json_ld_search_url` - allows you to change the search URL for your site.
 * `wpseo_schema_person_user_id` - allows changing the ID of the user we use to represent your site, should your site represent a person.

--- a/docs/features/schema/pieces/article.md
+++ b/docs/features/schema/pieces/article.md
@@ -147,3 +147,85 @@ Optional properties which should only be output when the required criteria are m
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change Article Schema output {#api}
+
+To change the `Article` schema Yoast SEO outputs, you can use our `wpseo_schema_article` filter, for instance as follows:
+
+```php
+add_filter( 'wpseo_schema_article', 'change_article_to_social_posting' );
+
+/**
+ * Changes @type of Article Schema data.
+ *
+ * @param array $data Schema.org Article data array.
+ *
+ * @return array Schema.org Article data array.
+ */
+function change_article_to_social_posting( $data ) {
+    $data['@type'] = 'SocialMediaPosting';
+
+    return $data;
+}
+```
+
+### Output Article schema on custom post types
+By default Yoast SEO doesn't output Article schema on custom post types. The code below changes that:
+
+```php
+/**
+ * Add 'book' to the list of articles post types, so books get Article schema.
+ *
+ * @param  mixed $post_types The current list of post types.
+ *
+ * @return array Array of post types for which Yoast SEO renders Article schema.
+ */
+function article_schema_for_books( $post_types ) {
+	$post_types[] = 'book';
+	return $post_types;
+}
+
+add_filter( 'wpseo_schema_article_post_types', 'article_schema_for_books' );
+```
+
+Note that for a post type to be able to output Article schema, the post type needs to support having an Author. You can add that simply by adding this, for a given post type `book`:
+
+```php
+add_post_type_support( 'book', 'author' );
+```
+
+This currently does not work for the `page` post type. We are fixing this.
+
+### Add images to your Article Schema
+If you want to add an image to an object programmatically, you can do it as follows. Note that we use the `YoastSEO`
+surface to get both the `canonical` from the `meta` surface as the `helpers` surface to access the `schema->image`
+functionality.
+
+```php
+add_filter( 'wpseo_schema_article', 'example_change_article' );
+
+/**
+ * Adds images to Article Schema data.
+ *
+ * @param array $data Schema.org Article data array.
+ *
+ * @return array Schema.org Article data array.
+ */
+function example_change_article( $data ) {
+    // This is the attachment ID for our image.
+    $attachment_id = 12345;
+
+    // We're going to create a graph piece for our image. Every graph piece always needs a Schema ID, so it can
+    // be referenced by other graph pieces, best practice is to base that on the canonical adding an ID that's
+    // always going to be unique.
+    $schema_id     = YoastSEO()->meta->for_current_page()->canonical . '#/schema/image/' . $attachment_id;                 
+    $data['image'] = new WPSEO_Schema_Image( $schema_id );
+
+    return $data;
+}
+```
+
+Instead of `YoastSEO()->helpers->schema->image->generate_from_attachment_id()` you can also use
+`YoastSEO()->helpers->schema->image->generate_from_url()` which takes, as you've guessed, a URL as input.
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/breadcrumb.md
+++ b/docs/features/schema/pieces/breadcrumb.md
@@ -122,3 +122,32 @@ Each `item`, except for the final/current 'crumb', had the following properties:
       ]
 }`}
 </YoastSchemaExample>
+
+## API: Change Breadcrumb Schema output {#api}
+
+To change the `Breadcrumb` schema Yoast SEO outputs, you can use our `wpseo_schema_breadcrumb` filter, for instance as follows:
+
+### Replace domain name in the breadcrumb schema
+If you want to replace the domain name in the breadcrumb schema, you can use the `wpseo_schema_breadcrumb` filter to hook into the breadcrumb schema piece individually.
+
+```php
+add_filter( 'wpseo_schema_breadcrumb', 'replace_domain_name_to_breadcrumb_schema', 11, 2 );
+/**
+ * Replace domain name in the breadcrumb schema piece individually.
+ * 
+ * @param array $piece Schema.org Breadcrumb data array.
+ * 
+ * @return array Altered Schema.org Breadcrumb data array.
+ */
+function replace_domain_name_to_breadcrumb_schema( $piece ) {
+    $piece['@id'] = str_replace( 'olddomain.tld', 'newdomain.tld', $piece['@id'] );
+    foreach ( $piece['itemListElement'] as &$list ) {
+        if ( $list['item'] ) {
+            $list['item'] = str_replace( 'olddomain.tld', 'newdomain.tld', $list['item'] );
+        }
+    }
+    return $piece;
+}
+```
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -6,7 +6,7 @@ description: Describes an organization (a company, business or institution). Mos
 ---
 import YoastSchemaExample from '../../../../src/components/YoastSchemaExample';
 
-Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a `WebSite`.
+Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a [`WebSite`](website.md).
 
 May be transformed into a more specific type (such as  `Corporation` or `LocalBusiness` ) if the required conditions are met.
 

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -91,3 +91,60 @@ The `Organization` type may be transformed in the following scenarios.
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change Organization Schema output {#api}
+
+To change the `Organization` schema Yoast SEO outputs, you can use our `wpseo_schema_organization` filter, for instance as follows:
+
+```php
+/**
+ * Changes the Yoast organization URL to always be https://yoast.com even on subdomains.
+ *
+ * @param array             $data    The Schema Organization data.
+ * @param Meta_Tags_Context $context Context value object.
+ *
+ * @return array $data The Schema Organization data.
+ */
+public function change_organization( array $data, Meta_Tags_Context $context ): array {
+	$data['@type'] = [
+		'Organization',
+		'Brand',
+	];
+	$data['founder'] = [
+		'@type'  => 'Person',
+		'name'   => 'Joost de Valk',
+		'url'    => 'https://yoast.com/about-us/team/joost-de-valk/',
+		'sameAs' => 'https://yoast.com/about-us/team/joost-de-valk/',
+	];
+	$data['foundingDate']       = '2010-05-01';
+	$data['numberOfEmployees']  = (int) wp_count_posts( 'yoast_employees' )->publish;
+	$data['slogan']             = 'SEO for Everyone';
+	$data['description']        = 'Yoast helps you with your website optimization, whether it be through our widely used SEO software or our online SEO courses: we&#039;re here to help.';
+	$data['url']                = 'https://yoast.com/';
+	$data['legalName']          = 'Yoast BV';
+	$data['parentOrganization'] = [
+		'@type'       => 'Organization',
+		'name'        => 'Newfold Digital',
+		'description' => 'Newfold Digital is a leading web presence solutions provider serving millions of small-to-medium businesses globally.',
+		'url'         => 'https://newfold.com/',
+		'sameAs'      => [
+			'https://newfold.com/',
+		],
+		'logo'        => 'https://yoast.com/app/uploads/2022/01/newfold-logo.png',
+	];
+	$data['memberOf']           = [
+		'@type'       => 'Organization',
+		'name'        => 'World Wide Web Consortium (W3C)',
+		'description' => 'The World Wide Web Consortium (W3C) is an international community that develops open standards to ensure the long-term growth of the Web.',
+		'url'         => 'https://w3.org/',
+		'sameAs'      => [
+			'https://w3.org/',
+		],
+		'logo'        => 'https://www.w3.org/Icons/w3c_main.png',
+	];
+
+	return $data;
+}
+```
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -97,6 +97,8 @@ The `Organization` type may be transformed in the following scenarios.
 To change the `Organization` schema Yoast SEO outputs, you can use our `wpseo_schema_organization` filter, for instance as follows:
 
 ```php
+add_filter( 'wpseo_schema_organization', 'change_organization_schema', 11, 2 );
+
 /**
  * Changes the Yoast organization URL to always be https://yoast.com even on subdomains.
  *
@@ -105,7 +107,7 @@ To change the `Organization` schema Yoast SEO outputs, you can use our `wpseo_sc
  *
  * @return array $data The Schema Organization data.
  */
-public function change_organization( array $data, Meta_Tags_Context $context ): array {
+function change_organization_schema( $data, $context ) {
 	$data['@type'] = [
 		'Organization',
 		'Brand',

--- a/docs/features/schema/pieces/person.md
+++ b/docs/features/schema/pieces/person.md
@@ -127,4 +127,24 @@ function change_schema_person_id( $person_id ) {
 }
 ```
 
+### Social profiles
+If you want to change which profiles to show on `Person` output in the `sameAs` array, you can hook into our `wpseo_schema_person_social_profiles` filter. We do this on yoast.com to add people's GitHub and WordPress profile as well as their personal sites to their sameAs output:
+
+```php
+add_filter( 'wpseo_schema_person_social_profiles', 'yoast_add_social_profiles' );
+
+/**
+ * Adds social profiles to our sameAs array.
+ *
+ * @param array $profiles Social profiles.
+ *
+ * @return array Social profiles.
+ */
+function yoast_add_social_profiles( $profiles ) {
+    array_push( $profiles, 'github', 'personal', 'wordpress' );
+
+    return $profiles;
+}
+```
+
 To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/person.md
+++ b/docs/features/schema/pieces/person.md
@@ -78,3 +78,53 @@ Optional properties which should only be output when the required criteria is me
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change Organization Schema output {#api}
+
+To change the `Person` schema Yoast SEO outputs, you can use our `wpseo_schema_person` filter, for instance as follows:
+
+### Change person output
+```php
+add_filter( 'wpseo_schema_person', 'schema_change_person', 11, 2 );
+
+/**
+ * Changes the Yoast SEO Person schema.
+ *
+ * @param array             $data    The Schema Person data.
+ * @param Meta_Tags_Context $context Context value object.
+ *
+ * @return array $data The Schema Person data.
+ */
+function schema_change_person( $data, $context ) {
+	if ( isset( $data['worksFor'] ) && $data['worksFor'] === 'Yoast' ) {
+		// Make references to "Yoast" actually reference the organization's graph piece.
+		$data['worksFor'] = [ '@id' => $context->site_url . Schema_IDs::ORGANIZATION_HASH ];
+	}
+
+	return $data;
+}
+```
+
+### Change person being output
+
+If you want to change the person being output in the schema, you can filter it like this:
+
+```php
+add_filter( 'wpseo_schema_person_user_id', 'change_schema_person_id' );
+
+/**
+ * Changes the Yoast SEO Person schema.
+ *
+ * @param int $person_id The Schema Person ID.
+ *
+ * @return int $person_id The (possibly altered) person ID.
+ */
+function change_schema_person_id( $person_id ) {
+    if ( $person_id === 12 ) {
+        return 3; // Make sure this is a valid user ID.
+    }
+    return $person_id;
+}
+```
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/searchaction.md
+++ b/docs/features/schema/pieces/searchaction.md
@@ -6,7 +6,7 @@ description: Describes a 'SearchAction' on a 'WebSite'.
 ---
 import YoastSchemaExample from '../../../../src/components/YoastSchemaExample';
 
-Describes a `SearchAction` on a `WebSite`.
+Describes a `SearchAction` on a [`WebSite`](website.md).
 
 ## Triggers
 Should be added as a `potentialAction` property on the `WebSite` node, when the site has/supports an internal search function.
@@ -42,3 +42,26 @@ If any of the required fields are missing or invalid, the node should not be out
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change SearchAction Schema output {#api}
+
+To change the `SearchAction` schema Yoast SEO outputs, you can use the following filters:
+
+### Disable `SearchAction` output
+This will disable the `SearchAction` output entirely:
+
+```php
+add_filter( 'disable_wpseo_json_ld_search', '__return_true' );
+```
+
+### Change `SearchAction` URL
+To change the search URL, use the `wpseo_json_ld_search_url` filter. Make sure that the URL you return contains a search parameter 
+variable `{search_term_string}` as otherwise it won't work.
+
+```php
+add_filter( 'wpseo_json_ld_search_url', 'schema_change_search_url' );
+
+function schema_change_search_url() {
+    return 'https://example.com/search/?q={search_term_string}';
+}
+```

--- a/docs/features/schema/pieces/searchaction.md
+++ b/docs/features/schema/pieces/searchaction.md
@@ -65,3 +65,5 @@ function schema_change_search_url() {
     return 'https://example.com/search/?q={search_term_string}';
 }
 ```
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/webpage.md
+++ b/docs/features/schema/pieces/webpage.md
@@ -6,9 +6,9 @@ Description: Describes a single page on a 'WebSite'. Acts as a container for sub
 ---
 import YoastSchemaExample from '../../../../src/components/YoastSchemaExample';
 
-Describes a single page on a `WebSite`. Acts as a container for sub-page elements (such as `Article`).
+Describes a single page on a [`WebSite`](website.md). Acts as a container for sub-page elements (such as [`Article`](article.md)).
 
-Acts as a connector from a page's content to the parent `WebSite` (and in turn, to the `Organization`).
+Acts as a connector from a page's content to the parent `WebSite` (and in turn, to the [`Organization`](organization.md)).
 
 May be transformed into a more specific type (such as `FAQPage` ) if the required conditions are met.
 

--- a/docs/features/schema/pieces/webpage.md
+++ b/docs/features/schema/pieces/webpage.md
@@ -147,3 +147,32 @@ On search results pages, the *type* property should be altered to an array of `[
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change Webpage Schema output {#api}
+
+To change the `Webpage` schema Yoast SEO outputs, you can use our `wpseo_schema_webpage` filter, for instance as follows:
+
+```php
+add_filter( 'wpseo_schema_webpage', 'example_change_webpage' );
+
+/**
+ * Changes @type of Webpage Schema data.
+ *
+ * @param array $data Schema.org Webpage data array.
+ *
+ * @return array Schema.org Webpage data array.
+ */
+function example_change_webpage( $data ) {
+    if ( ! is_page( 'about' ) ) {
+        return $data;
+    }
+
+    $data['@type'] = 'AboutPage';
+
+    return $data;
+}
+```
+
+We also have a more specific filter for convenience: `wpseo_schema_webpage_type` - changes the page type, so could be used to make the above example even simpler.
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/website.md
+++ b/docs/features/schema/pieces/website.md
@@ -61,6 +61,7 @@ The following should be added whenever available and valid:
               "@id": "https://www.example.com/#/schema/WebSite/1",
               "url": "https://www.example.com",
               "name": "Example website",
+              "alternateName": "Example.com",
               "inLanguage": "en-US",
               "potentialAction": {
                   "@type": "SearchAction",
@@ -74,3 +75,27 @@ The following should be added whenever available and valid:
       ]
   }`}
 </YoastSchemaExample>
+
+## API: Change Website Schema output {#api}
+
+To change the `Website` schema Yoast SEO outputs, you can use our `wpseo_schema_website` filter, for instance as follows:
+
+```php
+add_filter( 'wpseo_schema_website', 'example_change_website' );
+
+/**
+ * Changes Website Schema data output, overwriting the name and alternateName.
+ *
+ * @param array $data Schema.org Website data array.
+ *
+ * @return array Schema.org Website data array.
+ */
+function example_change_website( $data ) {
+    $data['name']          = 'Yoast';
+    $data['alternateName'] = 'Yoast.com';
+
+    return $data;
+}
+```
+
+To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).

--- a/docs/features/schema/pieces/website.md
+++ b/docs/features/schema/pieces/website.md
@@ -6,7 +6,7 @@ description: Describes a 'WebSite'. Parent to 'WebPage'.
 ---
 import YoastSchemaExample from '../../../../src/components/YoastSchemaExample';
 
-Describes a `WebSite`. Parent to `WebPage`.
+Describes a `WebSite`. Parent to [`WebPage`](webpage.md).
 
 ## Triggers
 Should be output on all public pages.
@@ -27,7 +27,7 @@ If any of the required fields are missing or invalid, the node should not be out
 The following should be added whenever available and valid:
 
 * `publisher`: A reference-by-ID to the node representing the entity which publishes the `WebSite`.
-* `potentialAction`: A `SearchAction` object describing the site's internal search.
+* `potentialAction`: A [`SearchAction`](searchaction.md) object describing the site's internal search.
 * `inLanguage`: The language code for the WebSite; e.g., `en-GB`.
  * If the website is available in multiple languages, then output an array of `inLanguage` values.
 * `description`: A description of the website (e.g., the site's tagline).
@@ -97,5 +97,7 @@ function example_change_website( $data ) {
     return $data;
 }
 ```
+
+To change the [`SearchAction`](searchaction.md) output, please see [its API documentation](searchaction.md#api).
 
 To make more changes to our Schema output, see the [Yoast SEO Schema API](../api.md).


### PR DESCRIPTION
## Summary
<!--
What does this PR change/introduce?
-->

* By moving the Schema API docs into the individual Pieces documentation pages, we make our Schema API much more accessible (and possibly even known).

## Quality assurance

* [x] I have tested my changes by running `yarn build`.

