### PR TITLE
Simplify og:image / twitter image stuff

### DIFF
--- a/docs/customization/apis/metadata-api.md
+++ b/docs/customization/apis/metadata-api.md
@@ -1,7 +1,6 @@
 ---
 id: metadata-api
 title: "Yoast SEO: Metadata API"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Metadata%20API
 sidebar_label: Metadata API
 description: Add, alter or remove metadata for a post or URL.
 ---

--- a/docs/customization/apis/overview.md
+++ b/docs/customization/apis/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast SEO - API overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20-%20API%20overview
 sidebar_label: Overview
 ---
 

--- a/docs/customization/apis/rest-api.md
+++ b/docs/customization/apis/rest-api.md
@@ -1,7 +1,6 @@
 ---
 id: rest-api
 title: "Yoast SEO: REST API"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20REST%20API
 sidebar_label: REST API
 description: Get all of the metadata for a post or URL in a single request, and as part of WordPress' WP-JSON response.
 ---

--- a/docs/customization/apis/surfaces-api.md
+++ b/docs/customization/apis/surfaces-api.md
@@ -1,7 +1,6 @@
 ---
 id: surfaces-api
 title: "Yoast SEO: Surfaces API"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Surfaces%20API
 sidebar_label: Surfaces API
 description: Retrieve metadata from a post or URL, seamlessly.
 ---

--- a/docs/customization/apis/using-apis-classes.md
+++ b/docs/customization/apis/using-apis-classes.md
@@ -1,7 +1,6 @@
 ---
 id: using-apis-classes
 title: "Yoast SEO: Using APIs and classes"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Using%20APIs%20and%20classes
 sidebar_label: Using APIs and classes
 ---
 

--- a/docs/customization/apis/using-apis-classes.md
+++ b/docs/customization/apis/using-apis-classes.md
@@ -1,7 +1,7 @@
 ---
 id: using-apis-classes
 title: "Yoast SEO: Using APIs and classes"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEUsing%20APIs%20and%20classes
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Using%20APIs%20and%20classes
 sidebar_label: Using APIs and classes
 ---
 

--- a/docs/customization/local-seo/changing-location-post-type.md
+++ b/docs/customization/local-seo/changing-location-post-type.md
@@ -1,7 +1,7 @@
 ---
 id: changing-location-post-type
 title: "Local SEO: Change the default Location post type"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO%20:NEWLINEChange%20the%20default%20Location%20post%20type
+image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO%20:%20Change%20the%20default%20Location%20post%20type
 sidebar_label: Change the default Location post type
 ---
 

--- a/docs/customization/local-seo/changing-location-post-type.md
+++ b/docs/customization/local-seo/changing-location-post-type.md
@@ -1,7 +1,6 @@
 ---
 id: changing-location-post-type
 title: "Local SEO: Change the default Location post type"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO%20:%20Change%20the%20default%20Location%20post%20type
 sidebar_label: Change the default Location post type
 ---
 

--- a/docs/customization/local-seo/changing-location-url-google-maps.md
+++ b/docs/customization/local-seo/changing-location-url-google-maps.md
@@ -1,7 +1,6 @@
 ---
 id: changing-location-url-google-maps
 title: "Local SEO: Change the Location URL in Google Maps"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Change%20the%20Location%20URL%20in%20Google%20Maps
 sidebar_label: Change the Location URL in Google Maps
 ---
 [Yoast SEO: Local](https://yoast.com/wordpress/plugins/local-seo/) and [Yoast SEO: Local SEO for WooCommerce](https://yoast.com/wordpress/plugins/local-seo-for-woocommerce/) include the ability to add a Google map for your location(s). The URL in the map, by default, points to the Yoast SEO location page on your website. In some cases, you may prefer to link to a different URL.

--- a/docs/customization/local-seo/changing-location-url-google-maps.md
+++ b/docs/customization/local-seo/changing-location-url-google-maps.md
@@ -1,7 +1,7 @@
 ---
 id: changing-location-url-google-maps
 title: "Local SEO: Change the Location URL in Google Maps"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:NEWLINEChange%20the%20Location%20URLNEWLINEin%20Google%20Maps
+image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Change%20the%20Location%20URL%20in%20Google%20Maps
 sidebar_label: Change the Location URL in Google Maps
 ---
 [Yoast SEO: Local](https://yoast.com/wordpress/plugins/local-seo/) and [Yoast SEO: Local SEO for WooCommerce](https://yoast.com/wordpress/plugins/local-seo-for-woocommerce/) include the ability to add a Google map for your location(s). The URL in the map, by default, points to the Yoast SEO location page on your website. In some cases, you may prefer to link to a different URL.

--- a/docs/customization/local-seo/changing-organization-url-in-schema.md
+++ b/docs/customization/local-seo/changing-organization-url-in-schema.md
@@ -1,7 +1,6 @@
 ---
 id: changing-organization-url-in-schema
 title: "Local SEO: Change the Organization URL in the Schema"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Change%20the%20Organization%20URL%20in%20the%20Schema
 sidebar_label: Change the Organization URL in the Schema
 ---
 

--- a/docs/customization/local-seo/changing-organization-url-in-schema.md
+++ b/docs/customization/local-seo/changing-organization-url-in-schema.md
@@ -1,7 +1,7 @@
 ---
 id: changing-organization-url-in-schema
 title: "Local SEO: Change the Organization URL in the Schema"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:NEWLINEChange%20the%20Organization%20URLNEWLINEin%20the%20Schema
+image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Change%20the%20Organization%20URL%20in%20the%20Schema
 sidebar_label: Change the Organization URL in the Schema
 ---
 

--- a/docs/customization/local-seo/enhancing-search-results.md
+++ b/docs/customization/local-seo/enhancing-search-results.md
@@ -1,7 +1,6 @@
 ---
 id: enhancing-search-results
 title: "Local SEO: Enhance search results"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Enhance%20search%20results
 sidebar_label: Enhance search results
 ---
 One of the hidden features of the Local SEO plugin is enhancing your website's internal search results with your location content. In rare cases, the enhanced search results can conflict with other plugin or theme features. Therefore, Local SEO version 7.1 introduced developer filters to disable these enhancements.

--- a/docs/customization/local-seo/enhancing-search-results.md
+++ b/docs/customization/local-seo/enhancing-search-results.md
@@ -1,7 +1,7 @@
 ---
 id: enhancing-search-results
 title: "Local SEO: Enhance search results"
-image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:NEWLINEEnhance%20search%20results
+image: https://yoast.com/shared-assets/opengraph/?title=Local%20SEO:%20Enhance%20search%20results
 sidebar_label: Enhance search results
 ---
 One of the hidden features of the Local SEO plugin is enhancing your website's internal search results with your location content. In rare cases, the enhanced search results can conflict with other plugin or theme features. Therefore, Local SEO version 7.1 introduced developer filters to disable these enhancements.

--- a/docs/customization/myyoast/apis/subscription-api.md
+++ b/docs/customization/myyoast/apis/subscription-api.md
@@ -1,7 +1,6 @@
 ---
 id: subscription-api
 title: "MyYoast: Subscription API"
-image: https://yoast.com/shared-assets/opengraph/?title=MyYoast:%20Subscription%20API
 sidebar_label: Subscription API
 description: For Yoast partners to create and manage subscriptions.
 ---

--- a/docs/customization/yoast-seo-premium/deprecations.md
+++ b/docs/customization/yoast-seo-premium/deprecations.md
@@ -1,7 +1,6 @@
 ---
 id: api-filter-actions-deprecations
 title: "Yoast SEO Premium: Deprecated filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Deprecated%20filters%20and%20actions
 sidebar_label: Deprecated filters & actions
 ---
 

--- a/docs/customization/yoast-seo-premium/deprecations.md
+++ b/docs/customization/yoast-seo-premium/deprecations.md
@@ -1,7 +1,7 @@
 ---
 id: api-filter-actions-deprecations
 title: "Yoast SEO Premium: Deprecated filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20PremiumNEWLINEDeprecated%20filters%20and%20actions
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Deprecated%20filters%20and%20actions
 sidebar_label: Deprecated filters & actions
 ---
 

--- a/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
+++ b/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
@@ -1,7 +1,6 @@
 ---
 id: disabling-automatic-redirects-notifications
 title: "Yoast SEO Premium: Disable automatic redirects and notifications"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Disable%20automatic%20redirects%20and%20notifications
 sidebar_label: Disable automatic redirects & notifications
 ---
 The Yoast SEO Premium's [redirects manager](https://yoast.com/wordpress/plugins/seo/redirects-manager/) includes automatic redirect creation and redirect request notifications. In rare cases, you may prefer to turn off some of these features.

--- a/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
+++ b/docs/customization/yoast-seo-premium/disabling-automatic-redirects-notifications.md
@@ -1,7 +1,7 @@
 ---
 id: disabling-automatic-redirects-notifications
 title: "Yoast SEO Premium: Disable automatic redirects and notifications"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20PremiumNEWLINEDisable%20automatic%20redirectsNEWLINEand%20notifications
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Disable%20automatic%20redirects%20and%20notifications
 sidebar_label: Disable automatic redirects & notifications
 ---
 The Yoast SEO Premium's [redirects manager](https://yoast.com/wordpress/plugins/seo/redirects-manager/) includes automatic redirect creation and redirect request notifications. In rare cases, you may prefer to turn off some of these features.

--- a/docs/customization/yoast-seo-premium/hiding-version-number.md
+++ b/docs/customization/yoast-seo-premium/hiding-version-number.md
@@ -1,7 +1,6 @@
 ---
 id: hiding-version-number
 title: "Yoast SEO Premium: Hide the version number"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Hide%20the%20version%20number
 sidebar_label: Hide the version number
 ---
 

--- a/docs/customization/yoast-seo-premium/hiding-version-number.md
+++ b/docs/customization/yoast-seo-premium/hiding-version-number.md
@@ -1,7 +1,7 @@
 ---
 id: hiding-version-number
 title: "Yoast SEO Premium: Hide the version number"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:NEWLINEHide%20the%20version%20number
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Premium:%20Hide%20the%20version%20number
 sidebar_label: Hide the version number
 ---
 

--- a/docs/customization/yoast-seo/adding-custom-assessments.md
+++ b/docs/customization/yoast-seo/adding-custom-assessments.md
@@ -1,7 +1,7 @@
 ---
 id: adding-custom-assessments
 title: "Yoast SEO: Adding custom assessments to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAdding%20custom%20assessmentsNEWLINEto%20the%20page%20analysis
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20assessments%20to%20the%20page%20analysis
 ---
 
 In addition to adding your own input fields to the pre-existing assessments that are available in Yoast SEO, it is also possible to write your own assessments that can analyze various aspects of a post, page or term. 

--- a/docs/customization/yoast-seo/adding-custom-assessments.md
+++ b/docs/customization/yoast-seo/adding-custom-assessments.md
@@ -1,7 +1,6 @@
 ---
 id: adding-custom-assessments
 title: "Yoast SEO: Adding custom assessments to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20assessments%20to%20the%20page%20analysis
 ---
 
 In addition to adding your own input fields to the pre-existing assessments that are available in Yoast SEO, it is also possible to write your own assessments that can analyze various aspects of a post, page or term. 

--- a/docs/customization/yoast-seo/adding-custom-data-analysis.md
+++ b/docs/customization/yoast-seo/adding-custom-data-analysis.md
@@ -1,7 +1,7 @@
 ---
 id: adding-custom-data-analysis
 title: "Yoast SEO: Adding custom data to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAdding%20custom%20dataNEWLINEto%20the%20page%20analysis
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20data%20to%20the%20page%20analysis
 ---
 
 Yoast SEO comes featured with a powerful set of tools to not only help you improve your SEO, but to also help you write better texts by analyzing the content of the post or page that you're working on.

--- a/docs/customization/yoast-seo/adding-custom-data-analysis.md
+++ b/docs/customization/yoast-seo/adding-custom-data-analysis.md
@@ -1,7 +1,6 @@
 ---
 id: adding-custom-data-analysis
 title: "Yoast SEO: Adding custom data to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20data%20to%20the%20page%20analysis
 ---
 
 Yoast SEO comes featured with a powerful set of tools to not only help you improve your SEO, but to also help you write better texts by analyzing the content of the post or page that you're working on.

--- a/docs/customization/yoast-seo/adding-custom-language-analysis.md
+++ b/docs/customization/yoast-seo/adding-custom-language-analysis.md
@@ -1,7 +1,7 @@
 ---
 id: adding-custom-language-analysis
 title: "Adding custom language to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAdding%20custom%20languageNEWLINEto%20the%20page%20analysis
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20language%20to%20the%20page%20analysis
 ---
 
 Our software supports multiple languages. If you wish to add your own custom language analysis, the analysis file needs to be available on the window. There are two ways to include the right language analysis JS file:

--- a/docs/customization/yoast-seo/adding-custom-language-analysis.md
+++ b/docs/customization/yoast-seo/adding-custom-language-analysis.md
@@ -1,7 +1,6 @@
 ---
 id: adding-custom-language-analysis
 title: "Adding custom language to the page analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Adding%20custom%20language%20to%20the%20page%20analysis
 ---
 
 Our software supports multiple languages. If you wish to add your own custom language analysis, the analysis file needs to be available on the window. There are two ways to include the right language analysis JS file:

--- a/docs/customization/yoast-seo/changing-enhanced-slack-sharing.md
+++ b/docs/customization/yoast-seo/changing-enhanced-slack-sharing.md
@@ -1,7 +1,6 @@
 ---
 id: changing-enhanced-slack-sharing
 title: "Yoast SEO: Change the Enhanced Slack sharing output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Change%20the%20Enhanced%20Slack%20sharing%20output
 sidebar_label: Enhanced Slack sharing
 ---
 

--- a/docs/customization/yoast-seo/changing-enhanced-slack-sharing.md
+++ b/docs/customization/yoast-seo/changing-enhanced-slack-sharing.md
@@ -1,7 +1,7 @@
 ---
 id: changing-enhanced-slack-sharing
 title: "Yoast SEO: Change the Enhanced Slack sharing output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEChange%20the%20EnhancedNEWLINESlack%20sharing%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Change%20the%20Enhanced%20Slack%20sharing%20output
 sidebar_label: Enhanced Slack sharing
 ---
 

--- a/docs/customization/yoast-seo/deprecations.md
+++ b/docs/customization/yoast-seo/deprecations.md
@@ -1,7 +1,6 @@
 ---
 id: api-filter-actions-deprecations
 title: "Yoast SEO: Deprecated filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Deprecated%20filters%20and%20actions
 sidebar_label: Deprecated filters & actions
 ---
 

--- a/docs/customization/yoast-seo/deprecations.md
+++ b/docs/customization/yoast-seo/deprecations.md
@@ -1,7 +1,7 @@
 ---
 id: api-filter-actions-deprecations
 title: "Yoast SEO: Deprecated filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEDeprecated%20filters%20and%20actions
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Deprecated%20filters%20and%20actions
 sidebar_label: Deprecated filters & actions
 ---
 

--- a/docs/customization/yoast-seo/disabling-primary-category.md
+++ b/docs/customization/yoast-seo/disabling-primary-category.md
@@ -1,7 +1,7 @@
 ---
 id: disabling-primary-category
 title: "Yoast SEO - Disabling the Primary category feature"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEDisabling%20Primary%20category%20feature
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disabling%20Primary%20category%20feature
 sidebar_label: Disabling the Primary category feature
 ---
 As of Yoast SEO 3.1, we've added the ability to [set a Primary category for a post](https://yoast.com/help/how-to-select-a-primary-category/). 

--- a/docs/customization/yoast-seo/disabling-primary-category.md
+++ b/docs/customization/yoast-seo/disabling-primary-category.md
@@ -1,7 +1,6 @@
 ---
 id: disabling-primary-category
 title: "Yoast SEO - Disabling the Primary category feature"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disabling%20Primary%20category%20feature
 sidebar_label: Disabling the Primary category feature
 ---
 As of Yoast SEO 3.1, we've added the ability to [set a Primary category for a post](https://yoast.com/help/how-to-select-a-primary-category/). 

--- a/docs/customization/yoast-seo/disabling-yoast-seo.md
+++ b/docs/customization/yoast-seo/disabling-yoast-seo.md
@@ -1,7 +1,6 @@
 ---
 id: disabling-yoast-seo
 title: "Yoast SEO: Disable Yoast SEO output for a specific page"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20output%20for%20a%20specific%20page
 sidebar_label: Disable Yoast SEO output
 ---
 As of Yoast SEO 14.0, we've changed the way you can interact with the output of Yoast SEO. 

--- a/docs/customization/yoast-seo/disabling-yoast-seo.md
+++ b/docs/customization/yoast-seo/disabling-yoast-seo.md
@@ -1,7 +1,7 @@
 ---
 id: disabling-yoast-seo
 title: "Yoast SEO: Disable Yoast SEO output for a specific page"
-image: https://yoast.com/shared-assets/opengraph/?title=Disable%20Yoast%20SEO%20outputNEWLINEfor%20a%20specific%20page
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20output%20for%20a%20specific%20page
 sidebar_label: Disable Yoast SEO output
 ---
 As of Yoast SEO 14.0, we've changed the way you can interact with the output of Yoast SEO. 

--- a/docs/customization/yoast-seo/filtering-yoast-blocks.md
+++ b/docs/customization/yoast-seo/filtering-yoast-blocks.md
@@ -1,7 +1,7 @@
 ---
 id: filtering-yoast-blocks
 title: "Yoast SEO: Filtering Yoast Blocks"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEFiltering%20Yoast%20Blocks
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Filtering%20Yoast%20Blocks
 sidebar_label: Filter Yoast Blocks
 ---
 As of [Yoast SEO 8.2](https://yoast.com/yoast-seo-8-2/), we've added our first two structured data blocks: The FAQ block and the How-To block.

--- a/docs/customization/yoast-seo/filtering-yoast-blocks.md
+++ b/docs/customization/yoast-seo/filtering-yoast-blocks.md
@@ -1,7 +1,6 @@
 ---
 id: filtering-yoast-blocks
 title: "Yoast SEO: Filtering Yoast Blocks"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Filtering%20Yoast%20Blocks
 sidebar_label: Filter Yoast Blocks
 ---
 As of [Yoast SEO 8.2](https://yoast.com/yoast-seo-8-2/), we've added our first two structured data blocks: The FAQ block and the How-To block.

--- a/docs/customization/yoast-seo/filters/assessment-markers-filter.md
+++ b/docs/customization/yoast-seo/filters/assessment-markers-filter.md
@@ -1,7 +1,7 @@
 ---
 id: assessment-markers-filter
 title: "Yoast SEO: Disable assessment markers"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEDisable%20assessment%20markers
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20assessmen%20markers
 sidebar_label: Disable assessment markers
 ---
 In some editors, the assessment markers in the SEO and readability analysis in Yoast SEO, will not be functional. To prevent confusion, the markers can be disabled.

--- a/docs/customization/yoast-seo/filters/assessment-markers-filter.md
+++ b/docs/customization/yoast-seo/filters/assessment-markers-filter.md
@@ -1,7 +1,6 @@
 ---
 id: assessment-markers-filter
 title: "Yoast SEO: Disable assessment markers"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20assessmen%20markers
 sidebar_label: Disable assessment markers
 ---
 In some editors, the assessment markers in the SEO and readability analysis in Yoast SEO, will not be functional. To prevent confusion, the markers can be disabled.

--- a/docs/customization/yoast-seo/filters/capability-roles-filter.md
+++ b/docs/customization/yoast-seo/filters/capability-roles-filter.md
@@ -1,7 +1,7 @@
 ---
 id: capability-roles-filter
 title: "Yoast SEO: Alter Yoast SEO capabilities for roles"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAlter%20Yoast%20SEO%20capabilitiesNEWLINEfor%20roles
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20Yoast%20SEO%20capabilities%20for%20roles
 sidebar_label: Alter Yoast SEO capabilities for roles
 ---
 Yoast SEO ships with a variety of custom capabilities that are assigned to various roles, which allow for granular control over what features are available for a particular role. However, in some cases you might want to expand or limit these capabilities. To support this, we’ve introduced a filter named `{$capability}_roles`, where `{$capability}` needs to be replaced with the name of one of the capabilities	that is registered by Yoast SEO.

--- a/docs/customization/yoast-seo/filters/capability-roles-filter.md
+++ b/docs/customization/yoast-seo/filters/capability-roles-filter.md
@@ -1,7 +1,6 @@
 ---
 id: capability-roles-filter
 title: "Yoast SEO: Alter Yoast SEO capabilities for roles"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20Yoast%20SEO%20capabilities%20for%20roles
 sidebar_label: Alter Yoast SEO capabilities for roles
 ---
 Yoast SEO ships with a variety of custom capabilities that are assigned to various roles, which allow for granular control over what features are available for a particular role. However, in some cases you might want to expand or limit these capabilities. To support this, we’ve introduced a filter named `{$capability}_roles`, where `{$capability}` needs to be replaced with the name of one of the capabilities	that is registered by Yoast SEO.

--- a/docs/customization/yoast-seo/filters/change-metabox-prio-filter.md
+++ b/docs/customization/yoast-seo/filters/change-metabox-prio-filter.md
@@ -1,7 +1,7 @@
 ---
 id: change-metabox-prio-filter
 title: "Yoast SEO: Change metabox priority"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEChange%20metabox%20priority
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Change%20metabox%20priority
 sidebar_label: Change metabox priority
 ---
 By default, the Yoast SEO metabox has a high priority. This means it will be displayed just below the editor. When needed, the priority can be lowered so it will be displayed below other metaboxes.

--- a/docs/customization/yoast-seo/filters/change-metabox-prio-filter.md
+++ b/docs/customization/yoast-seo/filters/change-metabox-prio-filter.md
@@ -1,7 +1,6 @@
 ---
 id: change-metabox-prio-filter
 title: "Yoast SEO: Change metabox priority"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Change%20metabox%20priority
 sidebar_label: Change metabox priority
 ---
 By default, the Yoast SEO metabox has a high priority. This means it will be displayed just below the editor. When needed, the priority can be lowered so it will be displayed below other metaboxes.

--- a/docs/customization/yoast-seo/filters/cornerstone-post-types-filter.md
+++ b/docs/customization/yoast-seo/filters/cornerstone-post-types-filter.md
@@ -1,7 +1,6 @@
 ---
 id: cornerstone-post-types-filter
 title: "Yoast SEO: Alter cornerstone post types"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20cornerstone%20post%20types
 sidebar_label: Alter Yoast SEO cornerstone post types
 ---
 Yoast SEO allows you to mark public (custom) post types as cornerstone content. In some cases, you might want to limit what can be marked.

--- a/docs/customization/yoast-seo/filters/cornerstone-post-types-filter.md
+++ b/docs/customization/yoast-seo/filters/cornerstone-post-types-filter.md
@@ -1,7 +1,7 @@
 ---
 id: cornerstone-post-types-filter
-title: "Yoast SEO: Alter Yoast SEO cornerstone post types"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAlter%20Yoast%20SEONEWLINEcornerstone%20post%20types
+title: "Yoast SEO: Alter cornerstone post types"
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20cornerstone%20post%20types
 sidebar_label: Alter Yoast SEO cornerstone post types
 ---
 Yoast SEO allows you to mark public (custom) post types as cornerstone content. In some cases, you might want to limit what can be marked.

--- a/docs/customization/yoast-seo/filters/disable-search-engine-pings.md
+++ b/docs/customization/yoast-seo/filters/disable-search-engine-pings.md
@@ -1,7 +1,7 @@
 ---
 id: disable-search-engine-pings
 title: "Yoast SEO: Disable search engine pings"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEDisable%20search%20engine%20pings
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20search%20engine%20pings
 sidebar_label: Disable search engine pings
 ---
 By default, Yoast SEO pings Google and Bing when you publish a new post with the URL of your XML sitemap. By doing this, the search engine can easily find the new URL and index it. If publishing on your site is disconnected from the URL being accessible live on the site, you will want to disable this functionality and do your own pings.

--- a/docs/customization/yoast-seo/filters/disable-search-engine-pings.md
+++ b/docs/customization/yoast-seo/filters/disable-search-engine-pings.md
@@ -1,7 +1,6 @@
 ---
 id: disable-search-engine-pings
 title: "Yoast SEO: Disable search engine pings"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Disable%20search%20engine%20pings
 sidebar_label: Disable search engine pings
 ---
 By default, Yoast SEO pings Google and Bing when you publish a new post with the URL of your XML sitemap. By doing this, the search engine can easily find the new URL and index it. If publishing on your site is disconnected from the URL being accessible live on the site, you will want to disable this functionality and do your own pings.

--- a/docs/customization/yoast-seo/filters/filtering-yoast-seo-indexables.md
+++ b/docs/customization/yoast-seo/filters/filtering-yoast-seo-indexables.md
@@ -1,7 +1,6 @@
 ---
 id: filtering-yoast-seo-indexables
 title: "Yoast SEO: Filter Indexables"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Filter%20indexables
 sidebar_label: Filter Yoast SEO Indexables
 ---
 

--- a/docs/customization/yoast-seo/filters/filtering-yoast-seo-indexables.md
+++ b/docs/customization/yoast-seo/filters/filtering-yoast-seo-indexables.md
@@ -1,7 +1,7 @@
 ---
 id: filtering-yoast-seo-indexables
-title: "Yoast SEO: Filter Yoast SEO Indexables"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEFilter%20Yoast%20SEO%20Indexables
+title: "Yoast SEO: Filter Indexables"
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Filter%20indexables
 sidebar_label: Filter Yoast SEO Indexables
 ---
 

--- a/docs/customization/yoast-seo/filters/markdown-enabled-filter.md
+++ b/docs/customization/yoast-seo/filters/markdown-enabled-filter.md
@@ -1,7 +1,7 @@
 ---
 id: markdown-enabled-filter
 title: "Yoast SEO - Enable Markdown for the SEO and readability analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEEnable%20Markdown%20for%20theNEWLINESEO%20and%20readability%20analysis
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Enable%20Markdown%20for%20the%20SEO%20and%20readability%20analysis&image_id=0
 sidebar_label: Enable Markdown for the SEO and readability analysis
 ---
 Yoast SEO can offer Markdown support in the SEO and readability analysis. This is disabled by default, unless Jetpack's Markdown module is enabled. It is possible to extend this to other plugins that parse Markdown in the content.

--- a/docs/customization/yoast-seo/filters/markdown-enabled-filter.md
+++ b/docs/customization/yoast-seo/filters/markdown-enabled-filter.md
@@ -1,7 +1,6 @@
 ---
 id: markdown-enabled-filter
 title: "Yoast SEO - Enable Markdown for the SEO and readability analysis"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Enable%20Markdown%20for%20the%20SEO%20and%20readability%20analysis&image_id=0
 sidebar_label: Enable Markdown for the SEO and readability analysis
 ---
 Yoast SEO can offer Markdown support in the SEO and readability analysis. This is disabled by default, unless Jetpack's Markdown module is enabled. It is possible to extend this to other plugins that parse Markdown in the content.

--- a/docs/customization/yoast-seo/filters/primary-term-taxonomies-filter.md
+++ b/docs/customization/yoast-seo/filters/primary-term-taxonomies-filter.md
@@ -1,7 +1,7 @@
 ---
 id: primary-term-taxonomies-filter
 title: "Yoast SEO: Alter Yoast SEO primary terms"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEAlter%20Yoast%20SEO%20primary%20terms
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20primary%20terms
 sidebar_label: Alter Yoast SEO primary terms
 ---
 Yoast SEO allows you to set categories as a primary term for posts and pages. In some cases, you might want to allow your users to use additional, custom taxonomies to be used as a primary term.

--- a/docs/customization/yoast-seo/filters/primary-term-taxonomies-filter.md
+++ b/docs/customization/yoast-seo/filters/primary-term-taxonomies-filter.md
@@ -1,7 +1,6 @@
 ---
 id: primary-term-taxonomies-filter
 title: "Yoast SEO: Alter Yoast SEO primary terms"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Alter%20primary%20terms
 sidebar_label: Alter Yoast SEO primary terms
 ---
 Yoast SEO allows you to set categories as a primary term for posts and pages. In some cases, you might want to allow your users to use additional, custom taxonomies to be used as a primary term.

--- a/docs/customization/yoast-seo/filters/yoast-seo-usage-tracking-filter.md
+++ b/docs/customization/yoast-seo/filters/yoast-seo-usage-tracking-filter.md
@@ -1,7 +1,6 @@
 ---
 id: yoast-seo-usage-tracking-filter
 title: "Yoast SEO: Enable usage tracking"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Enable%20usage%20tracking
 sidebar_label: Enable usage tracking
 ---
 Yoast SEO has a usage tracking feature to track basic site and server data, the plugin usage and the other plugins on the site as well as the theme used on the site.

--- a/docs/customization/yoast-seo/filters/yoast-seo-usage-tracking-filter.md
+++ b/docs/customization/yoast-seo/filters/yoast-seo-usage-tracking-filter.md
@@ -1,7 +1,7 @@
 ---
 id: yoast-seo-usage-tracking-filter
 title: "Yoast SEO: Enable usage tracking"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEEnable%20usage%20tracking
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Enable%20usage%20tracking
 sidebar_label: Enable usage tracking
 ---
 Yoast SEO has a usage tracking feature to track basic site and server data, the plugin usage and the other plugins on the site as well as the theme used on the site.

--- a/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
+++ b/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
@@ -1,7 +1,7 @@
 ---
 id: wp-get-environment-type-in-yoast-seo
 title: "Yoast SEO and wp_get_environment_type()"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20andNEWLINEwp_get_environment_type()
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20wp_get_environment_type()&image_id=1
 sidebar_label: wp_get_environment_type() in Yoast SEO
 ---
 Since WordPress 5.5, the new [`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/) function can be used to retrieve the current environment of a site. Among other things, this allows authors of themes and plugins to easily find the environment of a site, and possibly to propose specific features for each type of environment.

--- a/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
+++ b/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
@@ -1,7 +1,6 @@
 ---
 id: wp-get-environment-type-in-yoast-seo
 title: "Yoast SEO and wp_get_environment_type()"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20wp_get_environment_type()&image_id=1
 sidebar_label: wp_get_environment_type() in Yoast SEO
 ---
 Since WordPress 5.5, the new [`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/) function can be used to retrieve the current environment of a site. Among other things, this allows authors of themes and plugins to easily find the environment of a site, and possibly to propose specific features for each type of environment.

--- a/docs/development/cheatsheets.md
+++ b/docs/development/cheatsheets.md
@@ -1,7 +1,6 @@
 ---
 id: cheatsheets
 title: "Yoast development - Cheatsheets"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20development:%20Cheatsheets
 sidebar_label: Cheatsheets
 ---
 

--- a/docs/development/cheatsheets.md
+++ b/docs/development/cheatsheets.md
@@ -1,7 +1,7 @@
 ---
 id: cheatsheets
 title: "Yoast development - Cheatsheets"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20development:NEWLINECheatsheets
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20development:%20Cheatsheets
 sidebar_label: Cheatsheets
 ---
 

--- a/docs/development/environment/generating-unit-test-template.md
+++ b/docs/development/environment/generating-unit-test-template.md
@@ -1,7 +1,6 @@
 ---
 id: generating-unit-test-template
 title: "Yoast SEO development: Generating a unit test template"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20development:%20Generating%20a%20unit%20test%20template
 sidebar_label: Generating a unit test template
 ---
 Every class in the `src` folder should have an accompanying unit test in the `tests/unit` folder. Since setting up a new unit test file requires some boilerplate code, we created a handy tool that creates a unit test template for you.

--- a/docs/development/environment/generating-unit-test-template.md
+++ b/docs/development/environment/generating-unit-test-template.md
@@ -1,7 +1,7 @@
 ---
 id: generating-unit-test-template
 title: "Yoast SEO development: Generating a unit test template"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20development:NEWLINEGenerating%20a%20unit%20test%20template
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20development:%20Generating%20a%20unit%20test%20template
 sidebar_label: Generating a unit test template
 ---
 Every class in the `src` folder should have an accompanying unit test in the `tests/unit` folder. Since setting up a new unit test file requires some boilerplate code, we created a handy tool that creates a unit test template for you.

--- a/docs/development/environment/running-unit-tests-code-style-checks-and-linters.md
+++ b/docs/development/environment/running-unit-tests-code-style-checks-and-linters.md
@@ -1,7 +1,6 @@
 ---
 id: running-unit-tests-code-style-checks-and-linters
 title: "Yoast SEO Development: Unit tests, code style and linters"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Unit%20tests,%20code%20style%20and%20linters
 sidebar_label: Unit tests, code style & linters
 ---
 At Yoast we use a variety of tools to ensure our code adheres to a certain set of standards, which allow us to ship our products with more confidence and less bugs.

--- a/docs/development/environment/running-unit-tests-code-style-checks-and-linters.md
+++ b/docs/development/environment/running-unit-tests-code-style-checks-and-linters.md
@@ -1,7 +1,7 @@
 ---
 id: running-unit-tests-code-style-checks-and-linters
 title: "Yoast SEO Development: Unit tests, code style and linters"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:NEWLINEUnit%20tests,%20code%20style%20and%20linters
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Unit%20tests,%20code%20style%20and%20linters
 sidebar_label: Unit tests, code style & linters
 ---
 At Yoast we use a variety of tools to ensure our code adheres to a certain set of standards, which allow us to ship our products with more confidence and less bugs.

--- a/docs/development/environment/setup-plugin-integration-tests.md
+++ b/docs/development/environment/setup-plugin-integration-tests.md
@@ -1,7 +1,7 @@
 ---
 id: setup-plugin-integration-tests
 title: "Yoast SEO Development: Set up integration tests"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:NEWLINESet%20up%20integration%20tests
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Set%20up%20integration%20tests
 sidebar_label: Setting up integration tests
 description: When running integration tests we have to set up some WordPress Docker containers. This allows us to test against WordPress, which is the 'integration' part.
 ---

--- a/docs/development/environment/setup-plugin-integration-tests.md
+++ b/docs/development/environment/setup-plugin-integration-tests.md
@@ -1,7 +1,6 @@
 ---
 id: setup-plugin-integration-tests
 title: "Yoast SEO Development: Set up integration tests"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Set%20up%20integration%20tests
 sidebar_label: Setting up integration tests
 description: When running integration tests we have to set up some WordPress Docker containers. This allows us to test against WordPress, which is the 'integration' part.
 ---

--- a/docs/development/environment/setup.md
+++ b/docs/development/environment/setup.md
@@ -1,7 +1,6 @@
 ---
 id: setup
 title: "Yoast SEO development setup"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Development%20setup
 sidebar_label: Development setup
 ---
 

--- a/docs/development/environment/setup.md
+++ b/docs/development/environment/setup.md
@@ -1,7 +1,7 @@
 ---
 id: setup
 title: "Yoast SEO development setup"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development%20setup
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Development%20setup
 sidebar_label: Development setup
 ---
 

--- a/docs/development/environment/tools.md
+++ b/docs/development/environment/tools.md
@@ -1,7 +1,6 @@
 ---
 id: tools
 title: "Yoast SEO Development: Tools"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Tools
 sidebar_label: Development tools
 ---
 

--- a/docs/development/environment/tools.md
+++ b/docs/development/environment/tools.md
@@ -1,7 +1,7 @@
 ---
 id: tools
 title: "Yoast SEO Development: Tools"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:NEWLINETools
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Development:%20Tools
 sidebar_label: Development tools
 ---
 

--- a/docs/development/installation/using-composer.md
+++ b/docs/development/installation/using-composer.md
@@ -1,7 +1,7 @@
 ---
 id: using-composer
 title: "Yoast SEO: Install using Composer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEInstall%20using%20Composer
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Install%20using%20Composer
 sidebar_label: Using Composer
 ---
 

--- a/docs/development/installation/using-composer.md
+++ b/docs/development/installation/using-composer.md
@@ -1,7 +1,6 @@
 ---
 id: using-composer
 title: "Yoast SEO: Install using Composer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Install%20using%20Composer
 sidebar_label: Using Composer
 ---
 

--- a/docs/development/integrating.md
+++ b/docs/development/integrating.md
@@ -1,7 +1,6 @@
 ---
 id: integrating
 title: "Integrating Yoast SEO"
-image: https://yoast.com/shared-assets/opengraph/?title=Integrating%20Yoast%20SEO
 description: A hub for describing the technical specifications and requirements for integrating Yoast SEO.
 ---
 This documentation is a hub for describing the technical specifications and requirements for integrating [Yoast SEO](https://yoast.com/wordpress/plugins/seo/).

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Development - Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Development%20-%20Overview
 sidebar_label: Overview
 ---
 This page lists a variety of procedures, techniques and standards that we use during development here at Yoast.

--- a/docs/development/productivity-tips-and-tricks.md
+++ b/docs/development/productivity-tips-and-tricks.md
@@ -1,7 +1,7 @@
 ---
 id: productivity-tips-and-tricks
 title: "Development productivity: tips and tricks"
-image: https://yoast.com/shared-assets/opengraph/?title=Development%20productivity:NEWLINEtips%20and%20tricks
+image: https://yoast.com/shared-assets/opengraph/?title=Development%20productivity:%20Tips%20and%20tricks
 sidebar_label: Productivity tips & tricks
 ---
 

--- a/docs/development/productivity-tips-and-tricks.md
+++ b/docs/development/productivity-tips-and-tricks.md
@@ -1,7 +1,6 @@
 ---
 id: productivity-tips-and-tricks
 title: "Development productivity: tips and tricks"
-image: https://yoast.com/shared-assets/opengraph/?title=Development%20productivity:%20Tips%20and%20tricks
 sidebar_label: Productivity tips & tricks
 ---
 

--- a/docs/development/standards/coding-guidelines-and-principles.md
+++ b/docs/development/standards/coding-guidelines-and-principles.md
@@ -1,7 +1,6 @@
 ---
 id: coding-guidelines-and-principles
 title: "Yoast standards - Coding guidelines and principles"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Coding%20guidelines%20and%20principles
 sidebar_label: Coding guidelines and principles
 ---
 

--- a/docs/development/standards/coding-guidelines-and-principles.md
+++ b/docs/development/standards/coding-guidelines-and-principles.md
@@ -1,7 +1,7 @@
 ---
 id: coding-guidelines-and-principles
 title: "Yoast standards - Coding guidelines and principles"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:NEWLINECoding%20guidelines%20and%20principles
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Coding%20guidelines%20and%20principles
 sidebar_label: Coding guidelines and principles
 ---
 

--- a/docs/development/standards/phpunit-best-practices.md
+++ b/docs/development/standards/phpunit-best-practices.md
@@ -1,7 +1,7 @@
 ---
 id: phpunit-best-practices
 title: "Yoast standards - PhpUnit Best Practices"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:NEWLINEPhpUnit%20Best%20Practices
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20PhpUnit%20Best%20Practices
 sidebar_label: PhpUnit Best Practices
 ---
 

--- a/docs/development/standards/phpunit-best-practices.md
+++ b/docs/development/standards/phpunit-best-practices.md
@@ -1,7 +1,6 @@
 ---
 id: phpunit-best-practices
 title: "Yoast standards - PhpUnit Best Practices"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20PhpUnit%20Best%20Practices
 sidebar_label: PhpUnit Best Practices
 ---
 

--- a/docs/development/standards/version-control-conventions.md
+++ b/docs/development/standards/version-control-conventions.md
@@ -1,7 +1,6 @@
 ---
 id: version-control-conventions
 title: "Yoast standards - Version control conventions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Version%20control%20conventions
 sidebar_label: Version control conventions
 ---
 

--- a/docs/development/standards/version-control-conventions.md
+++ b/docs/development/standards/version-control-conventions.md
@@ -1,7 +1,7 @@
 ---
 id: version-control-conventions
 title: "Yoast standards - Version control conventions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:NEWLINEVersion%20control%20conventions
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Version%20control%20conventions
 sidebar_label: Version control conventions
 ---
 

--- a/docs/development/standards/writing-issues-and-pull-requests.md
+++ b/docs/development/standards/writing-issues-and-pull-requests.md
@@ -1,7 +1,6 @@
 ---
 id: writing-issues-and-pull-requests
 title: "Yoast standards - Writing issues and pull requests"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Writing%20issues%20and%20pull%20requests
 sidebar_label: Writing issues and pull requests
 ---
 

--- a/docs/development/standards/writing-issues-and-pull-requests.md
+++ b/docs/development/standards/writing-issues-and-pull-requests.md
@@ -1,7 +1,7 @@
 ---
 id: writing-issues-and-pull-requests
 title: "Yoast standards - Writing issues and pull requests"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:NEWLINEWriting%20issues%20and%20pull%20requests
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20standards:%20Writing%20issues%20and%20pull%20requests
 sidebar_label: Writing issues and pull requests
 ---
 

--- a/docs/duplicate-post/filters-actions.md
+++ b/docs/duplicate-post/filters-actions.md
@@ -1,7 +1,6 @@
 ---
 id: filters-actions
 title: "Yoast Duplicate Post - Filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20Post%20Filters%20and%20actions
 sidebar_label: Filters & actions
 ---
 

--- a/docs/duplicate-post/filters-actions.md
+++ b/docs/duplicate-post/filters-actions.md
@@ -1,7 +1,7 @@
 ---
 id: filters-actions
 title: "Yoast Duplicate Post - Filters and actions"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20PostNEWLINEFilters%20and%20actions
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20Post%20Filters%20and%20actions
 sidebar_label: Filters & actions
 ---
 

--- a/docs/duplicate-post/functions-template-tags.md
+++ b/docs/duplicate-post/functions-template-tags.md
@@ -1,7 +1,7 @@
 ---
 id: functions-template-tags
 title: "Yoast Duplicate Post - Functions and template tags"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20PostNEWLINEFunctions%20and%20template%20tags
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20Post%20Functions%20and%20template%20tags
 sidebar_label: Functions & template tags
 ---
 

--- a/docs/duplicate-post/functions-template-tags.md
+++ b/docs/duplicate-post/functions-template-tags.md
@@ -1,7 +1,6 @@
 ---
 id: functions-template-tags
 title: "Yoast Duplicate Post - Functions and template tags"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20Post%20Functions%20and%20template%20tags
 sidebar_label: Functions & template tags
 ---
 

--- a/docs/duplicate-post/overview.md
+++ b/docs/duplicate-post/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast Duplicate Post"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Duplicate%20Post
 sidebar_label: Overview
 ---
 

--- a/docs/features/alternate-formats/embedded.md
+++ b/docs/features/alternate-formats/embedded.md
@@ -1,7 +1,7 @@
 ---
 id: embedded
 title: "Embedded content - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Embedded%20content:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Embedded%20content:%20Functional%20specification
 sidebar_label: Embedded content
 description: This documentation explains how Yoast SEO modifies embedded content formats.
 ---

--- a/docs/features/alternate-formats/embedded.md
+++ b/docs/features/alternate-formats/embedded.md
@@ -1,7 +1,6 @@
 ---
 id: embedded
 title: "Embedded content - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Embedded%20content:%20Functional%20specification
 sidebar_label: Embedded content
 description: This documentation explains how Yoast SEO modifies embedded content formats.
 ---

--- a/docs/features/alternate-formats/rss-feeds.md
+++ b/docs/features/alternate-formats/rss-feeds.md
@@ -1,7 +1,6 @@
 ---
 id: rss-feeds
 title: "RSS Feeds - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=RSS%20Feeds:%20Functional%20specification
 sidebar_label: RSS Feeds
 description: This documentation explains Yoast SEO modifies RSS feeds.
 ---

--- a/docs/features/alternate-formats/rss-feeds.md
+++ b/docs/features/alternate-formats/rss-feeds.md
@@ -1,7 +1,7 @@
 ---
 id: rss-feeds
 title: "RSS Feeds - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=RSS%20Feeds:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=RSS%20Feeds:%20Functional%20specification
 sidebar_label: RSS Feeds
 description: This documentation explains Yoast SEO modifies RSS feeds.
 ---

--- a/docs/features/analysis/overview.md
+++ b/docs/features/analysis/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast SEO Content analysis: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Content%20analysis:%20Overview
 sidebar_label: Overview
 description: This documentation provides information about how Yoast SEO analyzes content.
 ---

--- a/docs/features/analysis/overview.md
+++ b/docs/features/analysis/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: "Yoast SEO Content analysis: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Content%20analysis:NEWLINEOverview
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Content%20analysis:%20Overview
 sidebar_label: Overview
 description: This documentation provides information about how Yoast SEO analyzes content.
 ---

--- a/docs/features/controls/link-attributes.md
+++ b/docs/features/controls/link-attributes.md
@@ -1,7 +1,6 @@
 ---
 id: link-attributes
 title: "Link Attributes - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Link%20Attributes%20Functional%20specification
 sidebar_label: Link attributes
 description: This documentation provides technical information about Yoast SEO manages link attributes.
 ---

--- a/docs/features/controls/link-attributes.md
+++ b/docs/features/controls/link-attributes.md
@@ -1,7 +1,7 @@
 ---
 id: link-attributes
 title: "Link Attributes - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINELink%20AttributesNEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20Link%20Attributes%20Functional%20specification
 sidebar_label: Link attributes
 description: This documentation provides technical information about Yoast SEO manages link attributes.
 ---

--- a/docs/features/controls/overview.md
+++ b/docs/features/controls/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Controls - Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Controls%20-%20Overview
 sidebar_label: Overview
 description: This documentation provides information about the types of controls that Yoast SEO provides.
 ---

--- a/docs/features/http-headers/functional-specification.md
+++ b/docs/features/http-headers/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "HTTP Headers - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20HTTP%20Headers%20Functional%20specification
 sidebar_label: HTTP headers
 description: An overview of how HTTP headers work in Yoast SEO.
 ---

--- a/docs/features/http-headers/functional-specification.md
+++ b/docs/features/http-headers/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "HTTP Headers - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEHTTP%20HeadersNEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20HTTP%20Headers%20Functional%20specification
 sidebar_label: HTTP headers
 description: An overview of how HTTP headers work in Yoast SEO.
 ---

--- a/docs/features/integrations/indexnow.md
+++ b/docs/features/integrations/indexnow.md
@@ -1,7 +1,6 @@
 ---
 id: indexnow
 title: "IndexNow - Yoast SEO Integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:%20IndexNow
 sidebar_label: IndexNow
 description: This documentation provides information about how Yoast SEO integrates with IndexNow.
 ---

--- a/docs/features/integrations/indexnow.md
+++ b/docs/features/integrations/indexnow.md
@@ -1,7 +1,7 @@
 ---
 id: indexnow
 title: "IndexNow - Yoast SEO Integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:NEWLINEIndexNow
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:%20IndexNow
 sidebar_label: IndexNow
 description: This documentation provides information about how Yoast SEO integrates with IndexNow.
 ---

--- a/docs/features/integrations/site-connections.md
+++ b/docs/features/integrations/site-connections.md
@@ -1,7 +1,6 @@
 ---
 id: site-connections
 title: "Site connections - Yoast SEO integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:%20Site%20connections
 sidebar_label: Site connections
 description: This documentation provides information about how Yoast SEO integrates with various search engine's tools and portals.
 ---

--- a/docs/features/integrations/site-connections.md
+++ b/docs/features/integrations/site-connections.md
@@ -1,7 +1,7 @@
 ---
 id: site-connections
 title: "Site connections - Yoast SEO integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:NEWLINESite%20connections
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20integrations:%20Site%20connections
 sidebar_label: Site connections
 description: This documentation provides information about how Yoast SEO integrates with various search engine's tools and portals.
 ---

--- a/docs/features/opengraph/api/changing-og-locale-output.md
+++ b/docs/features/opengraph/api/changing-og-locale-output.md
@@ -1,7 +1,6 @@
 ---
 id: changing-og-locale-output
 title: "Yoast SEO OpenGraph Tags: Change the og:locale output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20OpenGraph%20Tags:%20Change%20og:locale%20output
 sidebar_label: Changing the og:locale output
 ---
 

--- a/docs/features/opengraph/api/changing-og-locale-output.md
+++ b/docs/features/opengraph/api/changing-og-locale-output.md
@@ -1,7 +1,7 @@
 ---
 id: changing-og-locale-output
 title: "Yoast SEO OpenGraph Tags: Change the og:locale output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20OpenGraph%20Tags:NEWLINEChange%20the%20og:locale%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20OpenGraph%20Tags:%20Change%20og:locale%20output
 sidebar_label: Changing the og:locale output
 ---
 

--- a/docs/features/opengraph/api/wpseo-opengraph-images.md
+++ b/docs/features/opengraph/api/wpseo-opengraph-images.md
@@ -1,7 +1,7 @@
 ---
 id: wpseo-opengraph-images
 title: "Yoast SEO: change the OpenGraph image output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEChange%20OpenGraph%20image%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Change%20OpenGraph%20image%20output
 sidebar_label: Alter OpenGraph images output
 ---
 These filters allow altering an existing OpenGraph image and/or adding images to the output. 

--- a/docs/features/opengraph/api/wpseo-opengraph-images.md
+++ b/docs/features/opengraph/api/wpseo-opengraph-images.md
@@ -1,7 +1,6 @@
 ---
 id: wpseo-opengraph-images
 title: "Yoast SEO: change the OpenGraph image output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Change%20OpenGraph%20image%20output
 sidebar_label: Alter OpenGraph images output
 ---
 These filters allow altering an existing OpenGraph image and/or adding images to the output. 

--- a/docs/features/opengraph/extensions-and-addons.md
+++ b/docs/features/opengraph/extensions-and-addons.md
@@ -1,7 +1,6 @@
 ---
 id: extensions-and-addons
 title: "Yoast SEO OpenGraph tags: extensions and addons"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20OpenGraph%20tags%20-%20extensions%20and%20addons
 sidebar_label: Extensions & addons
 description: This documentation provides technical information about which additional meta tags our extensions and addons generate and output.
 ---

--- a/docs/features/opengraph/extensions-and-addons.md
+++ b/docs/features/opengraph/extensions-and-addons.md
@@ -1,7 +1,7 @@
 ---
 id: extensions-and-addons
 title: "Yoast SEO OpenGraph tags: extensions and addons"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEOpenGraph%20tags%20-NEWLINEextensions%20and%20addons
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20OpenGraph%20tags%20-%20extensions%20and%20addons
 sidebar_label: Extensions & addons
 description: This documentation provides technical information about which additional meta tags our extensions and addons generate and output.
 ---

--- a/docs/features/opengraph/functional-specification.md
+++ b/docs/features/opengraph/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO OpenGraph Tags: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20OpenGraph%20tags%20-%20Functional%20specification
 sidebar_label: Specification
 description: This documentation provides technical information about which OpenGraph tags Yoast SEO generates and outputs.
 ---

--- a/docs/features/opengraph/functional-specification.md
+++ b/docs/features/opengraph/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO OpenGraph Tags: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:NEWLINEOpenGraph%20tags%20-NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO:%20OpenGraph%20tags%20-%20Functional%20specification
 sidebar_label: Specification
 description: This documentation provides technical information about which OpenGraph tags Yoast SEO generates and outputs.
 ---

--- a/docs/features/robots-txt/functional-specification.md
+++ b/docs/features/robots-txt/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO: robots.txt - functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINERobots.txt%20-%20Functional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Robots.txt%20-%20Functional%20specification
 sidebar_label: robots.txt
 description: This documentation explains how Yoast SEO modifies robots.txt files.
 ---

--- a/docs/features/robots-txt/functional-specification.md
+++ b/docs/features/robots-txt/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO: robots.txt - functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Robots.txt%20-%20Functional%20specification
 sidebar_label: robots.txt
 description: This documentation explains how Yoast SEO modifies robots.txt files.
 ---

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Schema - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Schema%20-%20API%20documentation
 sidebar_label: Schema API
 description: Instructions on how to modify our schema output programmatically.
 ---

--- a/docs/features/schema/background.md
+++ b/docs/features/schema/background.md
@@ -1,7 +1,6 @@
 ---
 id: background
 title: "Schema - Background information"
-image: https://yoast.com/shared-assets/opengraph/?title=Schema%20-%20Background%20information
 sidebar_label: Background
 description: Information about our approach, rationale, and considerations when it comes to schema.org markup.
 ---

--- a/docs/features/schema/functional-specification.md
+++ b/docs/features/schema/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Schema - Specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Schema%20-%20Specification
 sidebar_label: Specification
 description: This page describes our functional and technical approach to constructing schema.org markup.
 ---

--- a/docs/features/schema/integration-guidelines.md
+++ b/docs/features/schema/integration-guidelines.md
@@ -1,7 +1,6 @@
 ---
 id: integration-guidelines
 title: "Schema - Integration guidelines"
-image: https://yoast.com/shared-assets/opengraph/?title=Schema%20-%20Integration%20guidelines
 sidebar_label: Integration guidelines
 description: Integrating with Yoast's structured data framework is easy, and, we encourage all plugin/theme/software authors to consider adopting and extending our approach.
 ---

--- a/docs/features/schema/pieces/aggregateoffer.md
+++ b/docs/features/schema/pieces/aggregateoffer.md
@@ -1,7 +1,6 @@
 ---
 id: aggregateoffer
 title: "Schema piece - AggregateOffer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20AggregateOffer
 sidebar_label: AggregateOffer
 description: Describes a group of 'offers' for a 'Product', typically due to variations in attributes (colors, sizes, prices).
 ---

--- a/docs/features/schema/pieces/aggregateoffer.md
+++ b/docs/features/schema/pieces/aggregateoffer.md
@@ -1,7 +1,7 @@
 ---
 id: aggregateoffer
 title: "Schema piece - AggregateOffer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEAggregateOffer
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20AggregateOffer
 sidebar_label: AggregateOffer
 description: Describes a group of 'offers' for a 'Product', typically due to variations in attributes (colors, sizes, prices).
 ---

--- a/docs/features/schema/pieces/article.md
+++ b/docs/features/schema/pieces/article.md
@@ -1,7 +1,7 @@
 ---
 id: article
 title: "Schema piece - Article"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEArticle
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Article
 sidebar_label: Article
 description: Describes an 'Article' on a 'WebPage'.
 ---

--- a/docs/features/schema/pieces/article.md
+++ b/docs/features/schema/pieces/article.md
@@ -1,7 +1,6 @@
 ---
 id: article
 title: "Schema piece - Article"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Article
 sidebar_label: Article
 description: Describes an 'Article' on a 'WebPage'.
 ---

--- a/docs/features/schema/pieces/breadcrumb.md
+++ b/docs/features/schema/pieces/breadcrumb.md
@@ -1,7 +1,6 @@
 ---
 id: breadcrumb
 title: "Schema piece - Breadcrumb"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Breadcrumb
 sidebar_label: Breadcrumb
 description: Describes the hierarchical position a 'WebPage' within a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/breadcrumb.md
+++ b/docs/features/schema/pieces/breadcrumb.md
@@ -1,7 +1,7 @@
 ---
 id: breadcrumb
 title: "Schema piece - Breadcrumb"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEBreadcrumb
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Breadcrumb
 sidebar_label: Breadcrumb
 description: Describes the hierarchical position a 'WebPage' within a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/comment.md
+++ b/docs/features/schema/pieces/comment.md
@@ -1,7 +1,7 @@
 ---
 id: comment
 title: "Schema piece - Comment"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEComment
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Comment
 sidebar_label: Comment
 description: Describes a review. Usually in the context of an 'Article' or a 'WebPage'.
 ---

--- a/docs/features/schema/pieces/comment.md
+++ b/docs/features/schema/pieces/comment.md
@@ -1,7 +1,6 @@
 ---
 id: comment
 title: "Schema piece - Comment"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Comment
 sidebar_label: Comment
 description: Describes a review. Usually in the context of an 'Article' or a 'WebPage'.
 ---

--- a/docs/features/schema/pieces/howto.md
+++ b/docs/features/schema/pieces/howto.md
@@ -1,7 +1,6 @@
 ---
 id: howto
 title: "Schema piece - HowTo"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20HowTo
 sidebar_label: HowTo
 description: Describes a 'HowTo' guide, which contains a series of 'steps'.
 ---

--- a/docs/features/schema/pieces/howto.md
+++ b/docs/features/schema/pieces/howto.md
@@ -1,7 +1,7 @@
 ---
 id: howto
 title: "Schema piece - HowTo"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEHowTo
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20HowTo
 sidebar_label: HowTo
 description: Describes a 'HowTo' guide, which contains a series of 'steps'.
 ---

--- a/docs/features/schema/pieces/image.md
+++ b/docs/features/schema/pieces/image.md
@@ -1,7 +1,6 @@
 ---
 id: image
 title: "Schema piece - ImageObject"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20ImageObject
 sidebar_label: Image (ImageObject)
 description: Describes an individual image (usually in the context of an embedded media object).
 ---

--- a/docs/features/schema/pieces/image.md
+++ b/docs/features/schema/pieces/image.md
@@ -1,7 +1,7 @@
 ---
 id: image
 title: "Schema piece - ImageObject"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEImageObject
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20ImageObject
 sidebar_label: Image (ImageObject)
 description: Describes an individual image (usually in the context of an embedded media object).
 ---

--- a/docs/features/schema/pieces/localbusiness.md
+++ b/docs/features/schema/pieces/localbusiness.md
@@ -1,7 +1,7 @@
 ---
 id: localbusiness
 title: "Schema piece - LocalBusiness"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINELocalBusiness
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20LocalBusiness
 sidebar_label: LocalBusiness
 description: Describes a business which allows public visitation. Typically used to represent the business 'behind' the website, or on a page about a specific business.
 ---

--- a/docs/features/schema/pieces/localbusiness.md
+++ b/docs/features/schema/pieces/localbusiness.md
@@ -1,7 +1,6 @@
 ---
 id: localbusiness
 title: "Schema piece - LocalBusiness"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20LocalBusiness
 sidebar_label: LocalBusiness
 description: Describes a business which allows public visitation. Typically used to represent the business 'behind' the website, or on a page about a specific business.
 ---

--- a/docs/features/schema/pieces/offer.md
+++ b/docs/features/schema/pieces/offer.md
@@ -1,7 +1,7 @@
 ---
 id: offer
 title: "Schema piece - Offer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEOffer
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Offer
 sidebar_label: Offer
 description: Describes an offer for a 'Product' (typically prices, stock availability, etc).
 ---

--- a/docs/features/schema/pieces/offer.md
+++ b/docs/features/schema/pieces/offer.md
@@ -1,7 +1,6 @@
 ---
 id: offer
 title: "Schema piece - Offer"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Offer
 sidebar_label: Offer
 description: Describes an offer for a 'Product' (typically prices, stock availability, etc).
 ---

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -1,7 +1,6 @@
 ---
 id: organization
 title: "Schema piece - Organization"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Organization
 sidebar_label: Organization
 description: Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/organization.md
+++ b/docs/features/schema/pieces/organization.md
@@ -1,7 +1,7 @@
 ---
 id: organization
 title: "Schema piece - Organization"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEOrganization
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Organization
 sidebar_label: Organization
 description: Describes an organization (a company, business or institution). Most commonly used to identify the publisher of a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/person.md
+++ b/docs/features/schema/pieces/person.md
@@ -1,7 +1,6 @@
 ---
 id: person
 title: "Schema piece - Person"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Person
 sidebar_label: Person
 description: Describes an individual person. Most commonly used to identify the 'author' of a piece of content.
 ---

--- a/docs/features/schema/pieces/person.md
+++ b/docs/features/schema/pieces/person.md
@@ -1,7 +1,7 @@
 ---
 id: person
 title: "Schema piece - Person"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEPerson
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Person
 sidebar_label: Person
 description: Describes an individual person. Most commonly used to identify the 'author' of a piece of content.
 ---

--- a/docs/features/schema/pieces/postaladdress.md
+++ b/docs/features/schema/pieces/postaladdress.md
@@ -1,7 +1,6 @@
 ---
 id: postaladdress
 title: "Schema piece - PostalAddress"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20PostalAddress
 sidebar_label: Postal Address
 description: Describes the postal address of a place; usually in the context of a 'LocalBusiness'.
 ---

--- a/docs/features/schema/pieces/postaladdress.md
+++ b/docs/features/schema/pieces/postaladdress.md
@@ -1,7 +1,7 @@
 ---
 id: postaladdress
 title: "Schema piece - PostalAddress"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEPostalAddress
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20PostalAddress
 sidebar_label: Postal Address
 description: Describes the postal address of a place; usually in the context of a 'LocalBusiness'.
 ---

--- a/docs/features/schema/pieces/product.md
+++ b/docs/features/schema/pieces/product.md
@@ -1,7 +1,7 @@
 ---
 id: product
 title: "Schema piece - Product"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEProduct
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Product
 sidebar_label: Product
 description: Describes a product sold by a business.
 ---

--- a/docs/features/schema/pieces/product.md
+++ b/docs/features/schema/pieces/product.md
@@ -1,7 +1,6 @@
 ---
 id: product
 title: "Schema piece - Product"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Product
 sidebar_label: Product
 description: Describes a product sold by a business.
 ---

--- a/docs/features/schema/pieces/question.md
+++ b/docs/features/schema/pieces/question.md
@@ -1,7 +1,7 @@
 ---
 id: question
 title: "Schema piece - Question"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEQuestion
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Question
 sidebar_label: Question
 description: Describes a 'Question'. Most commonly used in 'FAQPage' or 'QAPage' content.
 ---

--- a/docs/features/schema/pieces/question.md
+++ b/docs/features/schema/pieces/question.md
@@ -1,7 +1,6 @@
 ---
 id: question
 title: "Schema piece - Question"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Question
 sidebar_label: Question
 description: Describes a 'Question'. Most commonly used in 'FAQPage' or 'QAPage' content.
 ---

--- a/docs/features/schema/pieces/recipe.md
+++ b/docs/features/schema/pieces/recipe.md
@@ -1,7 +1,6 @@
 ---
 id: recipe
 title: "Schema piece - Recipe"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Recipe
 sidebar_label: Recipe
 description: Describes a 'Recipe', which contains a series of instructions, ingredients, and optional fields.
 ---

--- a/docs/features/schema/pieces/recipe.md
+++ b/docs/features/schema/pieces/recipe.md
@@ -1,7 +1,7 @@
 ---
 id: recipe
 title: "Schema piece - Recipe"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINERecipe
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Recipe
 sidebar_label: Recipe
 description: Describes a 'Recipe', which contains a series of instructions, ingredients, and optional fields.
 ---

--- a/docs/features/schema/pieces/review.md
+++ b/docs/features/schema/pieces/review.md
@@ -1,7 +1,6 @@
 ---
 id: review
 title: "Schema piece - Review"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Review
 sidebar_label: Review
 description: Describes a 'Review'. Usually in the context of a 'Product' or an 'Organization'.
 ---

--- a/docs/features/schema/pieces/review.md
+++ b/docs/features/schema/pieces/review.md
@@ -1,7 +1,7 @@
 ---
 id: review
 title: "Schema piece - Review"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEReview
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20Review
 sidebar_label: Review
 description: Describes a 'Review'. Usually in the context of a 'Product' or an 'Organization'.
 ---

--- a/docs/features/schema/pieces/searchaction.md
+++ b/docs/features/schema/pieces/searchaction.md
@@ -1,7 +1,7 @@
 ---
 id: searchaction
 title: "Schema piece - SearchAction"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINESearchAction
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20SearchAction
 sidebar_label: SearchAction
 description: Describes a 'SearchAction' on a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/searchaction.md
+++ b/docs/features/schema/pieces/searchaction.md
@@ -1,7 +1,6 @@
 ---
 id: searchaction
 title: "Schema piece - SearchAction"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20SearchAction
 sidebar_label: SearchAction
 description: Describes a 'SearchAction' on a 'WebSite'.
 ---

--- a/docs/features/schema/pieces/video.md
+++ b/docs/features/schema/pieces/video.md
@@ -1,7 +1,7 @@
 ---
 id: video
 title: "Schema piece - VideoObject"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEVideoObject
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20VideoObject
 sidebar_label: Video (VideoObject)
 description: Describes an individual video (usually in the context of an embedded media object).
 ---

--- a/docs/features/schema/pieces/video.md
+++ b/docs/features/schema/pieces/video.md
@@ -1,7 +1,6 @@
 ---
 id: video
 title: "Schema piece - VideoObject"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20VideoObject
 sidebar_label: Video (VideoObject)
 description: Describes an individual video (usually in the context of an embedded media object).
 ---

--- a/docs/features/schema/pieces/webpage.md
+++ b/docs/features/schema/pieces/webpage.md
@@ -1,7 +1,6 @@
 ---
 id: webpage
 title: "Schema piece - WebPage"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20WebPage
 sidebar_label: WebPage
 Description: Describes a single page on a 'WebSite'. Acts as a container for sub-page elements (such as 'Article').
 ---

--- a/docs/features/schema/pieces/webpage.md
+++ b/docs/features/schema/pieces/webpage.md
@@ -1,7 +1,7 @@
 ---
 id: webpage
 title: "Schema piece - WebPage"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEWebPage
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20WebPage
 sidebar_label: WebPage
 Description: Describes a single page on a 'WebSite'. Acts as a container for sub-page elements (such as 'Article').
 ---

--- a/docs/features/schema/pieces/website.md
+++ b/docs/features/schema/pieces/website.md
@@ -1,7 +1,6 @@
 ---
 id: website
 title: "Schema piece - WebSite"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20WebSite
 sidebar_label: WebSite
 description: Describes a 'WebSite'. Parent to 'WebPage'.
 ---

--- a/docs/features/schema/pieces/website.md
+++ b/docs/features/schema/pieces/website.md
@@ -1,7 +1,7 @@
 ---
 id: website
 title: "Schema piece - WebSite"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:NEWLINEWebSite
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Schema%20piece:%20WebSite
 sidebar_label: WebSite
 description: Describes a 'WebSite'. Parent to 'WebPage'.
 ---

--- a/docs/features/schema/plugins/local-seo.md
+++ b/docs/features/schema/plugins/local-seo.md
@@ -1,7 +1,7 @@
 ---
 id: local-seo
 title: "Yoast Local SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Local%20SEO%20for%20WordPress:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Local%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Local SEO for WordPress
 description: Describes the schema output of Yoast's "Local SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/local-seo.md
+++ b/docs/features/schema/plugins/local-seo.md
@@ -1,7 +1,6 @@
 ---
 id: local-seo
 title: "Yoast Local SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Local%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Local SEO for WordPress
 description: Describes the schema output of Yoast's "Local SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/news-seo.md
+++ b/docs/features/schema/plugins/news-seo.md
@@ -1,7 +1,7 @@
 ---
 id: news-seo
 title: "Yoast News SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20News%20SEO%20for%20WordPress:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20News%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: News SEO for WordPress
 description: Describes the schema output of Yoast's "News SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/news-seo.md
+++ b/docs/features/schema/plugins/news-seo.md
@@ -1,7 +1,6 @@
 ---
 id: news-seo
 title: "Yoast News SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20News%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: News SEO for WordPress
 description: Describes the schema output of Yoast's "News SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/video-seo.md
+++ b/docs/features/schema/plugins/video-seo.md
@@ -1,7 +1,7 @@
 ---
 id: video-seo
 title: "Yoast Video SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Video%20SEO%20for%20WordPress:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Video%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Video SEO for WordPress
 description: Describes the schema output of Yoast's "Video SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/video-seo.md
+++ b/docs/features/schema/plugins/video-seo.md
@@ -1,7 +1,6 @@
 ---
 id: video-seo
 title: "Yoast Video SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20Video%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Video SEO for WordPress
 description: Describes the schema output of Yoast's "Video SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/woocommerce-seo.md
+++ b/docs/features/schema/plugins/woocommerce-seo.md
@@ -1,7 +1,6 @@
 ---
 id: woocommerce-seo
 title: "Yoast WooCommerce SEO: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20WooCommerce%20SEO:%20Schema%20output
 sidebar_label: WooCommerce SEO
 description: Describes the schema output of Yoast's "WooCommerce SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/woocommerce-seo.md
+++ b/docs/features/schema/plugins/woocommerce-seo.md
@@ -1,7 +1,7 @@
 ---
 id: woocommerce-seo
 title: "Yoast WooCommerce SEO: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20WooCommerce%20SEO:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20WooCommerce%20SEO:%20Schema%20output
 sidebar_label: WooCommerce SEO
 description: Describes the schema output of Yoast's "WooCommerce SEO" plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/yoast-seo-shopify.md
+++ b/docs/features/schema/plugins/yoast-seo-shopify.md
@@ -1,7 +1,7 @@
 ---
 id: yoast-seo-shopify
 title: "Yoast SEO Shopify: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:%20Schema%20output
 sidebar_label: Yoast SEO for Shopify
 description: Describes the schema output of the Yoast SEO app for Shopify.
 ---

--- a/docs/features/schema/plugins/yoast-seo-shopify.md
+++ b/docs/features/schema/plugins/yoast-seo-shopify.md
@@ -1,7 +1,6 @@
 ---
 id: yoast-seo-shopify
 title: "Yoast SEO Shopify: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:%20Schema%20output
 sidebar_label: Yoast SEO for Shopify
 description: Describes the schema output of the Yoast SEO app for Shopify.
 ---

--- a/docs/features/schema/plugins/yoast-seo.md
+++ b/docs/features/schema/plugins/yoast-seo.md
@@ -1,7 +1,7 @@
 ---
 id: yoast-seo
 title: "Yoast SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20WordPress:NEWLINESchema%20output
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Yoast SEO for WordPress
 description: Describes the schema output of the Yoast SEO plugin for WordPress.
 ---

--- a/docs/features/schema/plugins/yoast-seo.md
+++ b/docs/features/schema/plugins/yoast-seo.md
@@ -1,7 +1,6 @@
 ---
 id: yoast-seo
 title: "Yoast SEO for WordPress: Schema output"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20WordPress:%20Schema%20output
 sidebar_label: Yoast SEO for WordPress
 description: Describes the schema output of the Yoast SEO plugin for WordPress.
 ---

--- a/docs/features/schema/technology-approach.md
+++ b/docs/features/schema/technology-approach.md
@@ -1,7 +1,6 @@
 ---
 id: technology-approach
 title: "Schema - Technology and approach"
-image: https://yoast.com/shared-assets/opengraph/?title=Schema%20-%20Technology%20and%20approach
 sidebar_label: Technology & approach
 description: An overview of some of the technical choices and standards used in our schema.org outputs.
 ---

--- a/docs/features/seo-tags/canonical-urls/api.md
+++ b/docs/features/seo-tags/canonical-urls/api.md
@@ -1,7 +1,7 @@
 ---
 id: api
 title: "Yoast SEO Canonical URLs - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINECanonical%20URLs:NEWLINEAPI%20documentation
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Canonical%20URLs:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our canonical URL values programmatically.
 ---

--- a/docs/features/seo-tags/canonical-urls/api.md
+++ b/docs/features/seo-tags/canonical-urls/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Yoast SEO Canonical URLs - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Canonical%20URLs:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our canonical URL values programmatically.
 ---

--- a/docs/features/seo-tags/canonical-urls/functional-specification.md
+++ b/docs/features/seo-tags/canonical-urls/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO: Canonical URLs - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Canonical%20URLs:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how canonical URLs work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/canonical-urls/functional-specification.md
+++ b/docs/features/seo-tags/canonical-urls/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO: Canonical URLs - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINECanonical%20URLs:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Canonical%20URLs:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how canonical URLs work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/descriptions/api.md
+++ b/docs/features/seo-tags/descriptions/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Yoast SEO Meta descriptions: API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20descriptions:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our description values programmatically.
 ---

--- a/docs/features/seo-tags/descriptions/api.md
+++ b/docs/features/seo-tags/descriptions/api.md
@@ -1,7 +1,7 @@
 ---
 id: api
 title: "Yoast SEO Meta descriptions: API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEMeta%20descriptions:NEWLINEAPI%20documentation
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20descriptions:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our description values programmatically.
 ---

--- a/docs/features/seo-tags/descriptions/functional-specification.md
+++ b/docs/features/seo-tags/descriptions/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Descriptions - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20descriptions:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how description tags work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/descriptions/functional-specification.md
+++ b/docs/features/seo-tags/descriptions/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Descriptions - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEMeta%20descriptions:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20descriptions:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how description tags work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/meta-robots/api.md
+++ b/docs/features/seo-tags/meta-robots/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Yoast SEO: Meta robots - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our meta robots values programmatically.
 ---

--- a/docs/features/seo-tags/meta-robots/api.md
+++ b/docs/features/seo-tags/meta-robots/api.md
@@ -1,7 +1,7 @@
 ---
 id: api
 title: "Yoast SEO: Meta robots - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEMeta%20robots:NEWLINEAPI%20documentation
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our meta robots values programmatically.
 ---

--- a/docs/features/seo-tags/meta-robots/functional-specification.md
+++ b/docs/features/seo-tags/meta-robots/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO Meta robots: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEMeta%20robots:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how meta robots tags work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/meta-robots/functional-specification.md
+++ b/docs/features/seo-tags/meta-robots/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO Meta robots: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how meta robots tags work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/meta-robots/overview.md
+++ b/docs/features/seo-tags/meta-robots/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast SEO Meta robots: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20Overview
 sidebar_label: Overview
 description: This documentation provides technical information about how Yoast SEO generates and/or manages meta robots tags.
 ---

--- a/docs/features/seo-tags/meta-robots/overview.md
+++ b/docs/features/seo-tags/meta-robots/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: "Yoast SEO Meta robots: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEMeta%20robots:%20Overview
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Meta%20robots:%20Overview
 sidebar_label: Overview
 description: This documentation provides technical information about how Yoast SEO generates and/or manages meta robots tags.
 ---

--- a/docs/features/seo-tags/titles/api.md
+++ b/docs/features/seo-tags/titles/api.md
@@ -1,7 +1,7 @@
 ---
 id: api
 title: "Yoast SEO Titles - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINETitles:%20API%20documentation
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Titles:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our title values programmatically.
 ---

--- a/docs/features/seo-tags/titles/api.md
+++ b/docs/features/seo-tags/titles/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Yoast SEO Titles - API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Titles:%20API%20documentation
 sidebar_label: API
 description: Instructions on how to modify our title values programmatically.
 ---

--- a/docs/features/seo-tags/titles/functional-specification.md
+++ b/docs/features/seo-tags/titles/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO titles - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20titles:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how title tags work in Yoast SEO.
 ---

--- a/docs/features/seo-tags/titles/functional-specification.md
+++ b/docs/features/seo-tags/titles/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO titles - Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20titles:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20titles:%20Functional%20specification
 sidebar_label: Specification
 description: An overview of how title tags work in Yoast SEO.
 ---

--- a/docs/features/twitter/functional-specification.md
+++ b/docs/features/twitter/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO Twitter Tags: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Twitter%20Tags:%20Functional%20specification
 sidebar_label: Twitter
 description: This documentation provides technical information about which twitter tags Yoast SEO generates and outputs.
 

--- a/docs/features/twitter/functional-specification.md
+++ b/docs/features/twitter/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO Twitter Tags: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Twitter%20Tags:NEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20Twitter%20Tags:%20Functional%20specification
 sidebar_label: Twitter
 description: This documentation provides technical information about which twitter tags Yoast SEO generates and outputs.
 

--- a/docs/features/wp-cli/reindex-indexables.md
+++ b/docs/features/wp-cli/reindex-indexables.md
@@ -1,7 +1,6 @@
 ---
 id: reindex-indexables
 title: "Yoast SEO WP CLI: Reindex Indexables command"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20WP%20CLI:%20Reindex%20Indexables%20command
 sidebar_label: Reindex Indexables
 ---
 

--- a/docs/features/wp-cli/reindex-indexables.md
+++ b/docs/features/wp-cli/reindex-indexables.md
@@ -1,7 +1,7 @@
 ---
 id: reindex-indexables
 title: "Yoast SEO WP CLI: Reindex Indexables command"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20WP%20CLI:NEWLINEReindex%20Indexables%20command
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20WP%20CLI:%20Reindex%20Indexables%20command
 sidebar_label: Reindex Indexables
 ---
 

--- a/docs/features/xml-sitemaps/api.md
+++ b/docs/features/xml-sitemaps/api.md
@@ -1,7 +1,6 @@
 ---
 id: api
 title: "Yoast SEO XML Sitemaps: API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20XML%20Sitemaps%20API%20documentation
 sidebar_label: API
 description: The API to change the XML sitemap Yoast SEO puts out.
 ---

--- a/docs/features/xml-sitemaps/api.md
+++ b/docs/features/xml-sitemaps/api.md
@@ -1,7 +1,7 @@
 ---
 id: api
 title: "Yoast SEO XML Sitemaps: API documentation"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEXML%20SitemapsNEWLINEAPI%20documentation
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20XML%20Sitemaps%20API%20documentation
 sidebar_label: API
 description: The API to change the XML sitemap Yoast SEO puts out.
 ---

--- a/docs/features/xml-sitemaps/functional-specification.md
+++ b/docs/features/xml-sitemaps/functional-specification.md
@@ -1,7 +1,6 @@
 ---
 id: functional-specification
 title: "Yoast SEO XML Sitemaps: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20XML%20Sitemaps%20Functional%20specification
 sidebar_label: Specification
 description: Description of Yoast SEO's functional and technical approach to constructing XML Sitemaps.
 ---

--- a/docs/features/xml-sitemaps/functional-specification.md
+++ b/docs/features/xml-sitemaps/functional-specification.md
@@ -1,7 +1,7 @@
 ---
 id: functional-specification
 title: "Yoast SEO XML Sitemaps: Functional specification"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEONEWLINEXML%20SitemapsNEWLINEFunctional%20specification
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20XML%20Sitemaps%20Functional%20specification
 sidebar_label: Specification
 description: Description of Yoast SEO's functional and technical approach to constructing XML Sitemaps.
 ---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: "Yoast developer portal"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20developer%20portalNEWLINENEWLINEThe%20home%20of%20Yoast%20SEO%20APIs
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20developer%20portal:%20The%20home%20of%20Yoast%20SEO%20APIs
 slug: /
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast developer portal"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20developer%20portal:%20The%20home%20of%20Yoast%20SEO%20APIs
 slug: /
 ---
 

--- a/docs/shopify/integrations.md
+++ b/docs/shopify/integrations.md
@@ -1,7 +1,6 @@
 ---
 id: integrations
 title: "Yoast SEO for Shopify: Integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify%20Integrations
 sidebar_label: Integrations
 description: Details about how Yoast SEO for Shopify integrates with apps and services
 ---

--- a/docs/shopify/integrations.md
+++ b/docs/shopify/integrations.md
@@ -1,7 +1,7 @@
 ---
 id: integrations
 title: "Yoast SEO for Shopify: Integrations"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20ShopifyNEWLINEIntegrations
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify%20Integrations
 sidebar_label: Integrations
 description: Details about how Yoast SEO for Shopify integrates with apps and services
 ---

--- a/docs/shopify/overview.md
+++ b/docs/shopify/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
 title: "Yoast SEO for Shopify: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:%20Overview
 sidebar_label: Overview
 description: An overview of how Yoast SEO for Shopify works
 ---

--- a/docs/shopify/overview.md
+++ b/docs/shopify/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: "Yoast SEO for Shopify: Overview"
-image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:NEWLINEOverview
+image: https://yoast.com/shared-assets/opengraph/?title=Yoast%20SEO%20for%20Shopify:%20Overview
 sidebar_label: Overview
 description: An overview of how Yoast SEO for Shopify works
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,10 +66,10 @@ const config = {
 						sidebarPath: require.resolve( "./sidebars.js" ),
 						// Please change this to your repo.
 						// Remove this to remove the "edit this page" links.
-						editUrl:
-							"https://github.com/yoast/developer/tree/main/",
+						editUrl: "https://github.com/yoast/developer/tree/main/",
 					},
 					blog: false,
+					pages: false,
 					theme: {
 						customCss: require.resolve( "./src/css/custom.css" ),
 					},

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {PageMetadata} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+export default function DocItemMetadata() {
+  const {metadata, frontMatter, assets} = useDoc();
+  const metaImage = "https://yoast.com/shared-assets/opengraph/?title=".concat( encodeURIComponent( metadata.title ) );
+  return (
+    <PageMetadata
+      title={metadata.title}
+      description={metadata.description}
+      keywords={frontMatter.keywords}
+      image={frontMatter.image ?? metaImage}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
<!--
What does this PR change/introduce?
-->

* Removes the need for an `image:` line in the frontmatter by [swizzling](https://docusaurus.io/docs/swizzling) the MetaData component from the theme. It still allows for an `image:` line in the frontmatter though.

## Quality assurance

* [x] I have tested my changes by running `yarn build`.

