### PR TITLE
Indexables Phase 2 docs

### DIFF
--- a/docs/features/indexables/filters.md
+++ b/docs/features/indexables/filters.md
@@ -97,3 +97,29 @@ function do_not_create_indexables_for_order_types( $excluded_taxonomies ) {
     return $excluded_taxonomies;
 }
 ```
+
+## Force including content
+
+
+### Force including post types {#included_post_types}
+
+The `wpseo_indexable_forced_included_post_types` filter takes an array of post types which indexables are to be created for. Make sure not to destroy that array, 
+just add to it. An example:
+
+```php
+add_filter( 'wpseo_indexable_forced_included_post_types', 'force_create_indexables_for_non_public_post_type' );
+
+/**
+ * Force create indexables for a post type that would otherwise not be eligible for Yoast SEO Indexable creation.
+ *
+ * @link https://developer.yoast.com/features/indexables/indexables-filters/#included_post_types
+ * 
+ * @param string[] $included_post_types Array of included post types by name.
+ * 
+ * @return string[]
+ */
+function force_create_indexables_for_non_public_post_type( $included_post_types ) {
+    $included_post_types[] = 'not_public_post_type';
+    return $included_post_types;
+}
+```

--- a/docs/features/indexables/technical-specification.md
+++ b/docs/features/indexables/technical-specification.md
@@ -28,18 +28,21 @@ considered indexable objects. Of course a post has to _exist_ to be a valid Inde
   Input([Post]) --> PTRegistered{Post <em>type</em> registered?}
   PTRegistered == Yes ==>PTExcluded{Post <em>type</em> excluded<br/><a href='/features/indexables/indexables-filters/#post_types'>through filter</a>?}
   PTRegistered -- No -->NoIndexable([Do <strong>not</strong> create an indexable])
-  PTExcluded -- Yes -->NoIndexable
+  PTExcluded -- Yes -->PTIncluded{Post <em>type</em> force included<br/><a href='/features/indexables/indexables-filters/#included_post_types'>through filter</a>?}
   PTExcluded == No ==>PTPublic{Is the<br/>post <em>type</em> <code>public</code>?}
   PTPublic == Yes ==>PTAttachment{Is the post<br/><em>type</em> <code>attachment</code>?}
+  PTPublic == No ==>PTIncluded
   PTAttachment -- Yes -->AttDisabled{Are <a href='https://yoast.com/features/redirect-attachment-urls/'>attachment URLs<br/> disabled</a> in Yoast SEO?}
-  AttDisabled -- Yes -->NoIndexable
+  AttDisabled -- Yes -->PTIncluded
   AttDisabled == No ==>PSRegistered{Post <em>status</em> registered?}
   PTAttachment == No ==>PSRegistered
   PSRegistered -- No -->NoIndexable
   PSRegistered == Yes ==>PSPublic{Is the post<br/><em>status</em> <code>public</code>?}
   PSPublic -- No -->IncludedNonPublishPostStatus{Post <em>status</em> one of:<br/><code>draft</code>, <code>pending</code>, <code>future</code>?}
-  IncludedNonPublishPostStatus == Yes ==>CreateIndexable
+  PTIncluded == No -->NoIndexable
+  PTIncluded == Yes -->CreateIndexable
   IncludedNonPublishPostStatus -- No -->NoIndexable
+  IncludedNonPublishPostStatus == Yes ==>CreateIndexable
   PSPublic == Yes ==>CreateIndexable([Create an indexable])
   style Input fill:#ddf,stroke:#aaf,stroke-width:2px
   style NoIndexable fill:#ffcccc,stroke:#f00,stroke-width:2px


### PR DESCRIPTION
Note 1: To be merged right after the 20.2 release
Note 2: After merged PR gets deployed, please check that the diagram (specifically the `Post type force included via filter` link) points to the new filter

## Summary
<!-- What does this PR change/introduce? -->

* Adds a section describing the new `wpseo_indexable_forced_included_post_types` filter
* Updates the `Which "things" get an indexable` diagram, accordingly

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
