### PR TITLE
Fix product schema offers declaration description

### DIFF
--- a/docs/features/schema/pieces/product.md
+++ b/docs/features/schema/pieces/product.md
@@ -27,7 +27,7 @@ If the node is not output, any entities which would otherwise have declared them
 ## Optional properties
 The following should be added whenever available and valid:
 
-* `offers`: An array of references-by-ID to one or more `Offer` or `AggregateOffer` pieces.
+* `offers`: A reference by ID to an `Offer` or `AggregateOffer` piece.
 * `brand`: A reference to an `Organization` piece, representing brand associated with the `Product`.
 * `seller`: A reference to an `Organization` piece which represents the `WebSite.`
 * `description`: A text description of the product.


### PR DESCRIPTION
## Summary
<!-- What does this PR change/introduce? -->

The described property cannot be a list, but has to be a reference to an offer (or aggregate offer as that is a derivative of an offer).

See the Schema docs for the declaration: https://schema.org/Product

The example also shows an object with an `@id` instead of a list.

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
