### PR TITLE
Adds windows command to make db accessible for integration tests

### DIFF
--- a/docs/development/environment/setup-plugin-integration-tests.md
+++ b/docs/development/environment/setup-plugin-integration-tests.md
@@ -47,6 +47,11 @@ sudo ifconfig lo0 alias 10.254.254.254
 sudo ifconfig lo:0 10.254.254.254
 ```
 
+* on Windows:
+```shell script
+netsh interface ipv4 add address "Loopback Pseudo-Interface 1" 10.254.254.254 255.255.255.255
+```
+
 ## Spin up the containers
 If you've gone through all the above steps, it's time to start the containers!
 


### PR DESCRIPTION
## Summary
<!-- What does this PR change/introduce? -->

* Adds the Windows version of the ifconfig command to make the DB accessible when setting up the integration tests

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
