### PR TITLE
Add documentation to disable table of content filter

### DIFF
--- a/docs/customization/yoast-seo-premium/disable-table-of-content-block.md
+++ b/docs/customization/yoast-seo-premium/disable-table-of-content-block.md
@@ -1,0 +1,15 @@
+---
+id: disable-table-of-content-block
+title: "Yoast SEO Premium: Disable Table of Content Block"
+sidebar_label: Disable Table of Content Block
+---
+
+We added a filter in Yoast SEO Premium version 21.5 to allow disabling the `Table of Content` block.
+
+Used to prevent auto-generation of HTML anchors for headings when `Table of Content` block is registered.
+
+Please add the following code to your theme's `functions.php` file.
+
+```php
+add_filter( 'Yoast\WP\SEO\disable_table_of_content_block', '__return_true' );
+```

--- a/docs/customization/yoast-seo-premium/disable-table-of-content-block.md
+++ b/docs/customization/yoast-seo-premium/disable-table-of-content-block.md
@@ -1,14 +1,12 @@
 ---
 id: disable-table-of-content-block
-title: "Yoast SEO Premium: Disable Table of Content Block"
-sidebar_label: Disable Table of Content Block
+title: "Yoast SEO Premium: Disable the Table of Content Block"
+sidebar_label: Disable the Table of Content Block
 ---
 
-We added a filter in Yoast SEO Premium version 21.5 to allow disabling the `Table of Content` block.
+We added a filter in Yoast SEO Premium 21.5 to allow disabling the `Table of Content` block. This is useful to prevent the auto-generation of HTML anchors for headings when the `Table of Content` block is registered, if you are not using the TOC block at all.
 
-Used to prevent auto-generation of HTML anchors for headings when `Table of Content` block is registered.
-
-Please add the following code to your theme's `functions.php` file.
+Add a snippet like this one in your theme's `functions.php` file:
 
 ```php
 add_filter( 'Yoast\WP\SEO\disable_table_of_content_block', '__return_true' );

--- a/sidebars.js
+++ b/sidebars.js
@@ -313,6 +313,7 @@ module.exports = {
 						'customization/yoast-seo-premium/disabling-automatic-redirects-notifications',
 						'customization/yoast-seo-premium/disabling-autoloading-redirect-options',
 						'customization/yoast-seo-premium/hiding-version-number',
+						'customization/yoast-seo-premium/disable-table-of-content-block',
 					],
 				},
 				{


### PR DESCRIPTION
## Summary
<!-- What does this PR change/introduce? -->

* Adds documentation to `Yoast\WP\SEO\disable_table_of_content_block` filter.

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
