### PR TITLE
Remove mention of deleted constant `WEBPAGE_HASH`

### DIFF
--- a/changelogs/wordpress-seo.md
+++ b/changelogs/wordpress-seo.md
@@ -23,6 +23,7 @@ We've just released Yoast SEO 21.9. This release comes with many behind-the-scen
 * Be explicit about required PHP extensions.
 * Improves PHP 8.2 compatibility.
 * Sets the minimum supported WordPress version to 6.3.
+* Removes the `WEBPAGE_HASH` constant that had been deprecated in Yoast SEO 19.3 (July 2022).
 
 = 21.8.1 =
 

--- a/docs/features/schema/api.md
+++ b/docs/features/schema/api.md
@@ -105,7 +105,7 @@ function add_custom_schema_piece( $pieces, $context ) {
 
 ## Referencing other graph pieces
 You can always reference the Yoast SEO core graph pieces using their fixed IDs. You can find those by using the
-`Schema_IDs` class. So you can find for instance `Schema_IDs::WEBPAGE_HASH`, `Schema_IDs::PERSON_LOGO_HASH` and many
+`Schema_IDs` class. So you can find for instance `Schema_IDs::ORGANIZATION_HASH`, `Schema_IDs::PERSON_LOGO_HASH` and many
 others. For instance if a piece you are adding needs to reference the `Organization` piece, all you have to do is this:
 
 ```php


### PR DESCRIPTION
## Summary
<!-- What does this PR change/introduce? -->

The constant had been removed in 19.3 (July 2022)
* removed mention in the docs
* added changelog line to Free 21.9

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
