### PR TITLE
254 - Duplicate titles in pagination

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -395,6 +395,7 @@ module.exports = {
 					label: 'Integrations',
 					link: {
 						type: 'generated-index',
+						title: 'Integration for Yoast Shopify SEO',
 						description: 'This documentation provides information about integrations for Yoast SEO for Shopify.',
 						slug: '/shopify/integrations/',
 					},

--- a/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
+++ b/src/plugins/changelog/theme/ChangelogList/Header/index.tsx
@@ -61,12 +61,14 @@ function RssLink() {
 
 export default function ChangelogListHeader({
   blogTitle,
+  page,
 }: {
   blogTitle: string;
+  page: number;
 }): JSX.Element {
   return (
     <header className="margin-bottom--lg">
-      <h1 style={{fontSize: '3rem'}}>{blogTitle}</h1>
+      <h1 style={{fontSize: '3rem'}}>{blogTitle} {page > 1 ? `- page ${page}`  : ``}</h1>
       <p>
         <Translate
           id="changelog.description"

--- a/src/plugins/changelog/theme/ChangelogList/index.tsx
+++ b/src/plugins/changelog/theme/ChangelogList/index.tsx
@@ -34,10 +34,10 @@ function ChangelogListMetadata(props: Props): JSX.Element {
 
 function ChangelogListContent(props: Props): JSX.Element {
   const {metadata, items, sidebar} = props;
-  const {blogTitle} = metadata;
+  const {blogTitle, page} = metadata;
   return (
     <BlogLayout sidebar={sidebar}>
-      <ChangelogListHeader blogTitle={blogTitle} />
+      <ChangelogListHeader blogTitle={blogTitle} page={page} />
       <BlogPostItems items={items} component={ChangelogItem} />
       <BlogListPaginator metadata={metadata} />
     </BlogLayout>

--- a/src/plugins/changelog/theme/ChangelogList/index.tsx
+++ b/src/plugins/changelog/theme/ChangelogList/index.tsx
@@ -24,9 +24,11 @@ function ChangelogListMetadata(props: Props): JSX.Element {
   const {metadata} = props;
   const {blogTitle, blogDescription} = metadata;
   const image = "https://yoast.com/shared-assets/opengraph/?title=" + encodeURIComponent( blogTitle + 's: Features, enhancements and bugfixes' );
+  const blogTitleSuffix = ` - page ${metadata.page}`;
+  const blogDescriptionSuffix = ` Page ${metadata.page}.`;
   return (
     <>
-      <PageMetadata title={blogTitle} description={blogDescription} image={image} />
+      <PageMetadata title={blogTitle + blogTitleSuffix} description={blogDescription + blogDescriptionSuffix} image={image} />
       <SearchMetadata tag="blog_posts_list" />
     </>
   );


### PR DESCRIPTION
fixes #254 #247 

## Summary
<!-- What does this PR change/introduce? -->
It fixes pagination page titles as well as meta descriptions. Rewrites one page title.

## Testing
1. Checkout `developer` repo. Check in the branch.
2. Run `yarn start`. Follow instructions in terminal. Wait for build to launch inside your default browser.
3. Go to `Changelogs` "archive" for any of the plugins.
4. On 1st page you do not see `- page [n]` suffix in `<h1 />`. On second page (etc)  you see `- page [n]` suffix.
5. Inside `<title></title>` tag you see `- page [n]` suffix.
6. Inside `<meta name="description" />` tag you see `Page [n].` suffix.
7. This [page](https://developer.yoast.com/shopify/integrations/) (locally) has `<title />` and `<h1 />` tags populated with value of `Integration for Yoast Shopify SEO`

## Quality assurance

* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: your pull can only be merged when the build succeeds, even by admins. 
You can test this locally by running `yarn build`. -->
