### PR TITLE
Add docs for open graph filters

### DIFF
--- a/docs/features/opengraph/api/custom-post-type-filters.md
+++ b/docs/features/opengraph/api/custom-post-type-filters.md
@@ -1,5 +1,5 @@
 ---
-id: wpseo-opengraph-custom-post-type-filters
+id: wpseo-opengraph-post-type-filters
 title: "Yoast SEO: Change the OpenGraph tags for post type"
 sidebar_label: Alter OpenGraph output for post type
 ---

--- a/docs/features/opengraph/api/custom-post-type-filters.md
+++ b/docs/features/opengraph/api/custom-post-type-filters.md
@@ -4,7 +4,7 @@ title: "Yoast SEO: Change the OpenGraph tags for post type"
 sidebar_label: Alter OpenGraph output for post type
 ---
 These filters allow altering an existing OpenGraph output for a specific post type. <br />
-They are also used in `Yoast SEO Premium` for Social media appearance, with priority 10. When using with `Yoast SEO Premium`, make sure to use the right priotity to avoid conflicts.
+They are used in `Yoast SEO Premium` for Social media appearance for the default post, with priority 10. When using with `Yoast SEO Premium`, make sure to use the right priotity to avoid conflicts.
 
 ## Alter the OpenGraph title
 

--- a/docs/features/opengraph/api/custom-post-type-filters.md
+++ b/docs/features/opengraph/api/custom-post-type-filters.md
@@ -4,7 +4,7 @@ title: "Yoast SEO: Change the OpenGraph tags for post type"
 sidebar_label: Alter OpenGraph output for post type
 ---
 These filters allow altering an existing OpenGraph output for a specific post type. <br />
-They are used in `Yoast SEO Premium` for Social media appearance for the default post, with priority 10. When using with `Yoast SEO Premium`, make sure to use the right priotity to avoid conflicts.
+They are used in `Yoast SEO Premium` for Social media appearance for the default post, with priority 10. When using with `Yoast SEO Premium`, make sure to use the right priority to avoid conflicts.
 
 ## Alter the OpenGraph title
 

--- a/docs/features/opengraph/api/custom-post-type-filters.md
+++ b/docs/features/opengraph/api/custom-post-type-filters.md
@@ -1,0 +1,91 @@
+---
+id: wpseo-opengraph-custom-post-type-filters
+title: "Yoast SEO: Change the OpenGraph tags for post type"
+sidebar_label: Alter OpenGraph output for post type
+---
+These filters allow altering an existing OpenGraph output for a specific post type. <br />
+They are also used in `Yoast SEO Premium` for Social media appearance, with priority 10. When using with `Yoast SEO Premium`, make sure to use the right priotity to avoid conflicts.
+
+## Alter the OpenGraph title
+
+Sets the `og:title` value returned by the filter. 
+Embed the post type in the filter name:
+
+```php
+add_filter( 'Yoast\WP\SEO\open_graph_title_{post_type}', 'callback_function' );
+```
+
+### Usage
+
+```php
+<?php
+/**
+ * Alter the OpenGraph title for post type `post.
+ * 
+ * @param  string $title   The default OpenGraph title.
+ * @param  int    $post_id The post ID.
+ * @return string The new OpenGraph title.
+ */
+public function alter_open_graph_title_for_post( $title, $post_type ) {
+    // Add your logic here.
+
+    return $title;
+}
+add_filter( 'Yoast\WP\SEO\open_graph_title_post', 'alter_open_graph_title_for_post', 10, 2 );
+```
+
+## Alter the OpenGraph description
+
+Sets the `og:description` value returned by the filter. 
+Embed the post type in the filter name:
+
+```php
+add_filter( 'Yoast\WP\SEO\open_graph_description_{post_type}', 'callback_function' );
+```
+
+### Usage
+
+```php
+<?php
+/**
+ * Alter the OpenGraph description for post type `post`.
+ * 
+ * @param  string  $description The default OpenGraph description.
+ * @param  string  $post_type   The post type.
+ * @return string  The new OpenGraph description.
+ */
+public function alter_open_graph_description_for_post( $description, $post_type ) {
+    // Add your logic here.
+
+    return $description;
+}
+add_filter( 'Yoast\WP\SEO\open_graph_description_post', 'alter_open_graph_description_for_post', 10, 2 );
+```
+
+## Alter the OpenGraph image
+
+Sets the `og:image` value returned by the filter. 
+Embed the post type in the filter name:
+
+```php
+add_filter( 'Yoast\WP\SEO\open_graph_image_{post_type}', 'callback_function' );
+```
+
+### Usage
+
+```php
+<?php
+/**
+ * Alter the OpenGraph image for post type `post.
+ * 
+ * @param  string $image     The default image URL.
+ * @param  string $post_type The post type.
+ * @return string The new image URL.
+ */
+public function alter_open_graph_image_for_post( $image, $post_type ) {
+    // Add your logic here.
+
+    return $image;
+}
+add_filter( 'Yoast\WP\SEO\open_graph_image_post', 'alter_open_graph_image_for_post', 10, 2 );
+```

--- a/docs/features/opengraph/api/custom-post-type-filters.md
+++ b/docs/features/opengraph/api/custom-post-type-filters.md
@@ -20,7 +20,7 @@ add_filter( 'Yoast\WP\SEO\open_graph_title_{post_type}', 'callback_function' );
 ```php
 <?php
 /**
- * Alter the OpenGraph title for post type `post.
+ * Alter the OpenGraph title for post type `post`.
  * 
  * @param  string $title   The default OpenGraph title.
  * @param  int    $post_id The post ID.
@@ -76,7 +76,7 @@ add_filter( 'Yoast\WP\SEO\open_graph_image_{post_type}', 'callback_function' );
 ```php
 <?php
 /**
- * Alter the OpenGraph image for post type `post.
+ * Alter the OpenGraph image for post type `post`.
  * 
  * @param  string $image     The default image URL.
  * @param  string $post_type The post type.
@@ -88,4 +88,32 @@ public function alter_open_graph_image_for_post( $image, $post_type ) {
     return $image;
 }
 add_filter( 'Yoast\WP\SEO\open_graph_image_post', 'alter_open_graph_image_for_post', 10, 2 );
+```
+
+## Alter the OpenGraph image by id
+
+Sets the Open Graph image values by the image id returned by the filter. 
+Embed the post type in the filter name:
+
+```php
+add_filter( 'Yoast\WP\SEO\open_graph_image_id_{post_type}', 'callback_function' );
+```
+
+### Usage
+
+```php
+<?php
+/**
+ * Alter the OpenGraph image for post type `post`.
+ * 
+ * @param  int    $image_id  The default image id.
+ * @param  string $post_type The post type.
+ * @return string The new image id.
+ */
+public function alter_open_graph_image_id_for_post( $image_id, $post_type ) {
+    // Add your logic here.
+
+    return $image_id;
+}
+add_filter( 'Yoast\WP\SEO\open_graph_image_id_post', 'alter_open_graph_image_id_for_post', 10, 2 );
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -145,6 +145,7 @@ module.exports = {
 							items: [
 								'features/opengraph/api/changing-og-locale-output',
 								'features/opengraph/api/wpseo-opengraph-images',
+								'features/opengraph/api/wpseo-opengraph-custom-post-type-filters',
 							]
 						},
 					],

--- a/sidebars.js
+++ b/sidebars.js
@@ -145,7 +145,7 @@ module.exports = {
 							items: [
 								'features/opengraph/api/changing-og-locale-output',
 								'features/opengraph/api/wpseo-opengraph-images',
-								'features/opengraph/api/wpseo-opengraph-custom-post-type-filters',
+								'features/opengraph/api/wpseo-opengraph-post-type-filters',
 							]
 						},
 					],


### PR DESCRIPTION
Fixes #

## Summary
<!-- What does this PR change/introduce? -->

Adds documentation for open graph filter for post types.

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:
Under `Yoast SEO Features`->`OpenGraph`->`API`
1. Check there is documentation for `Yoast\WP\SEO\open_graph_title_{post_type}` filter.
2. Check there is documentation for `Yoast\WP\SEO\open_graph_description_{post_type}` filter.
3. Check there is documentation for `Yoast\WP\SEO\open_graph_image_{post_type}` filter.

## Quality assurance
* [X] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
