### PR TITLE
Rename Twitter to X in documentation

### DIFF
--- a/docs/customization/apis/metadata-api.md
+++ b/docs/customization/apis/metadata-api.md
@@ -32,7 +32,7 @@ By default, Yoast SEO ships with the following presenters that output meta tags.
 | `Pinterest_Presenter` | `<meta name="p:domain_verify" content="%s" />` | n/a |
 | `Yandex_Presenter` | `<meta name="yandex-verification" content="%s" />` | n/a |
 
-### Twitter presenters
+### X presenters
 | Presenter | Tag format | Filter |
 |---|-----|----|
 | `Creator_Presenter` | `<meta name="twitter:creator" content="%s" />` | n/a |

--- a/docs/customization/apis/rest-api.md
+++ b/docs/customization/apis/rest-api.md
@@ -131,7 +131,7 @@ The following code is the result of a query to https://yoast.com/wp-json/yoast/v
                   "https:\/\/www.youtube.com\/yoast",
                   "https:\/\/www.pinterest.com\/yoast\/",
                   "https:\/\/en.wikipedia.org\/wiki\/Yoast",
-                  "https:\/\/twitter.com\/yoast"
+                  "https:\/\/x.com\/yoast"
                ],
                "logo":{
                   "@type":"ImageObject",
@@ -298,7 +298,7 @@ The following code is the result of a query to https://yoast.com/wp-json/yoast/v
                   "https:\/\/www.facebook.com\/mariekerakt",
                   "https:\/\/www.instagram.com\/mgarakt\/",
                   "https:\/\/www.linkedin.com\/in\/mariekerakt",
-                  "https:\/\/twitter.com\/mariekerakt",
+                  "https:\/\/x.com\/mariekerakt",
                   "https:\/\/marieke.blog\/",
                   "https:\/\/profiles.wordpress.org\/mariekerakt\/"
                ],

--- a/docs/customization/apis/surfaces-api.md
+++ b/docs/customization/apis/surfaces-api.md
@@ -68,12 +68,12 @@ The `current_page` surface exposes every bit of data we have on the current page
 | open_graph_article_modified_time | string | The article:modified_time value. |
 | open_graph_locale | string | The og:locale for the current page. |
 | schema | array | The entire Schema array for the current page. |
-| twitter_card | string | The Twitter card type for the current page. |
-| twitter_title | string | The Twitter card title for the current page. |
-| twitter_description | string | The Twitter card description for the current page. |
-| twitter_image | string | The Twitter card image for the current page. |
-| twitter_creator | string | The Twitter card author for the current page. |
-| twitter_site | string | The Twitter card site reference for the current page. |
+| twitter_card | string | The X card type for the current page. |
+| twitter_title | string | The X card title for the current page. |
+| twitter_description | string | The X card description for the current page. |
+| twitter_image | string | The X card image for the current page. |
+| twitter_creator | string | The X card author for the current page. |
+| twitter_site | string | The X card site reference for the current page. |
 | source | array | The source object for most of this page data. |
 | breadcrumbs | array | The breadcrumbs array for the current page. |
 | estimated_reading_time_minutes | int | The estimated reading time in minutes for the content. | 

--- a/docs/customization/yoast-seo/deprecations.md
+++ b/docs/customization/yoast-seo/deprecations.md
@@ -12,7 +12,7 @@ to point you to their replacements.
 ### Filters
 
 #### `wpseo_twitter_taxonomy_image`
-You can now always filter the Twitter image on any page, including a taxonomy page through the `wpseo_twitter_image` filter.
+You can now always filter the X image on any page, including a taxonomy page through the `wpseo_twitter_image` filter.
 
 #### `wpseo_twitter_metatag_key`
 We removed this filter without a replacement. Please add a new meta data presenter per [this documentation](/customization/apis/metadata-api/) if you need to add more values.

--- a/docs/development/integrating.md
+++ b/docs/development/integrating.md
@@ -24,7 +24,7 @@ All pages and content types should output metadata in line with the following st
 * [Canonical URL tags](features/seo-tags/canonical-urls/functional-specification.md)
 * [Meta robots tags](features/seo-tags/meta-robots/functional-specification.md)
 * [Open Graph tags](features/opengraph/functional-specification.md)
-* [Twitter tags](features/twitter/functional-specification.md)
+* [X tags](features/twitter/functional-specification.md)
 * [Alternate content formats](/features/alternate-formats/)
 
 ### Structured data

--- a/docs/features/controls/overview.md
+++ b/docs/features/controls/overview.md
@@ -14,7 +14,7 @@ As a site owner, I want to be able to set the following metadata globally.
 | Option | Description | Values |
 | --- | ----- | --- |
 | `og:site_name` | The name of the site for when shared in social platforms | `string` |
-| `twitter:site` | The Twitter handle of the Twitter profile associated with the site | `string` |
+| `twitter:site` | The X handle of the X profile associated with the site | `string` |
 | *Social profiles* | An array of the URLs of social media properties representing the publisher | `array` |
 | *Title separator* | The character used to delimit a page's 'name' and brand components in the *title* tag | `char` |
 

--- a/docs/features/schema/functional-specification.md
+++ b/docs/features/schema/functional-specification.md
@@ -72,7 +72,7 @@ The following examples demonstrate how our base script may be extended and alter
                   "https://www.youtube.com/example/",
                   "https://www.pinterest.com/example/",
                   "https://en.wikipedia.org/wikiexample/",
-                  "https://twitter.com/example/"
+                  "https://x.com/example/"
               ],
               "logo": {
                   "@type": "ImageObject",
@@ -138,7 +138,7 @@ The following examples demonstrate how our base script may be extended and alter
                   "https://www.youtube.com/example/",
                   "https://www.pinterest.com/example/",
                   "https://en.wikipedia.org/wikiexample/",
-                  "https://twitter.com/example/"
+                  "https://x.com/example/"
               ],
               "logo": {
                   "@type": "ImageObject",
@@ -279,7 +279,7 @@ Note that these are actually two separate graph blocks in reality, that are stit
                   "https://www.youtube.com/example/",
                   "https://www.pinterest.com/example/",
                   "https://en.wikipedia.org/wikiexample/",
-                  "https://twitter.com/example/"
+                  "https://x.com/example/"
               ],
               "logo": {
                   "@type": "ImageObject",
@@ -507,6 +507,6 @@ To work around this, we merge the `Person` with an `Organization` to create a hy
 ### 7. Other consumers
 At the time of publishing, it appears that Bing does not support this approach; their 'Markup Validator' tool (part of [Bing Webmaster Tools](https://www.bing.com/toolbox/webmaster)) does not detect (and/or parse) markup contained within a `@graph` structure (which forms the backbone of our approach). We're seeking to engage in dialogue with Bing to determine their stance on support.
 
-Social platforms like Facebook, Twitter, Pinterest, etc, have varying levels of support for this markup. Most rely on *Open Graph* markup ('OG tags') and similar, but may use components of schema.org markup when OG tags are missing or invalid.
+Social platforms like Facebook, X, Pinterest, etc, have varying levels of support for this markup. Most rely on *Open Graph* markup ('OG tags') and similar, but may use components of schema.org markup when OG tags are missing or invalid.
 
 The support of other search engines (e.g., Baidu, Yandex, others) is unknown; it's our assumption that support will generated be limited, or not exist. We hope that the broad adoption of our approach will encourage these, and other consumers, to expand their support.

--- a/docs/features/schema/plugins/yoast-seo-shopify.md
+++ b/docs/features/schema/plugins/yoast-seo-shopify.md
@@ -52,7 +52,7 @@ When these criteria are met, we produce our [base script](https://developer.yoas
             "sameAs": [
                 "https://www.wikipedia.com/example-organization",
                 "https://facebook.com/example-organization",
-                "https://twitter.com/example-organization",
+                "https://x.com/example-organization",
                 "https://www.instagram.com/example-organization"
             ]
         },

--- a/docs/features/twitter/functional-specification.md
+++ b/docs/features/twitter/functional-specification.md
@@ -1,38 +1,38 @@
 ---
 id: functional-specification
-title: "Yoast SEO Twitter Tags: Functional specification"
-sidebar_label: Twitter
-description: This documentation provides technical information about which twitter tags Yoast SEO generates and outputs.
+title: "Yoast SEO X Tags: Functional specification"
+sidebar_label: X
+description: This documentation provides technical information about which X tags Yoast SEO generates and outputs.
 
 ---
-This documentation provides technical information about which twitter tags [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) generates and outputs. These tags are only consumed by Twitter.
+This documentation provides technical information about which X tags [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) generates and outputs. These tags are only consumed by X.
 
-We output a variety of `<meta>` tags for Twitter in the `<head>` of each page, in order to better inform Twitter about the content of the page in question.
+We output a variety of `<meta>` tags for X in the `<head>` of each page, in order to better inform X about the content of the page in question.
 
-Note that for a lot of tags, Twitter falls back on OpenGraph metadata. Where it falls back, we provide the OpenGraph metadata and don't provide the Twitter tag specifically unless it has been customized.
+Note that for a lot of tags, X falls back on OpenGraph metadata. Where it falls back, we provide the OpenGraph metadata and don't provide the X tag specifically unless it has been customized.
 
-## Twitter metadata
-The following tags provide social networks and platforms (e.g., Facebook, Twitter, Pinterest) with additional information about the page and its content.
+## X metadata
+The following tags provide social networks and platforms (e.g., Facebook, X, Pinterest) with additional information about the page and its content.
 
 Assuming that the respective admin settings are not disabled, these tags are output on all pages (except for _error_ templates, which are described separately).
 
 | Tag | Description |
 |---|----|
 | twitter:card | The card type to use when previewing the page (defaulting to `summary_large_image`). |
-| twitter:site | The twitter handle of the site owner/operator. |
+| twitter:site | The X handle of the site owner/operator. |
 
 ## Conditional tags
 The following tags are only output when their conditions are met:
 
 | Tag | Description | Notes |
 |---|----|---|
-| twitter:creator | The twitter handle of the content author. | Only populated when the content author has a valid Twitter handle. <br /> Only populated on `post` types. |
-| twitter:title | The title of the page, specifically for sharing on Twitter. | Only populated when a specific value (which is different from the `og:title` value) is defined for Twitter. |
-| twitter:description | The description of the page, specifically for sharing on Twitter. | Only populated when a specific value (different from the `og:description` value) is defined for Twitter. <br /> <br /> The hierarchy for this is as follows: <ul><li>A user-defined "Twitter description" value for the page.</li><li>An auto-generated "Social description" from the template in Search Appearance.</li><li>No output, i.e. falls back on `og:description`.</li></ul> |
-| twitter:image | The URL of the primary image of the page, specifically for sharing on Twitter. | Only populated when a specific image (different from the `og:image`) is defined for Twitter, or, when Facebook / `og:image` tags are disabled. <br /> <br /> <ul><li>A user-defined “Twitter image” in the Social tab of the Yoast metabox in a `twitter:image` tag</li><li>A user-defined “Facebook image” in the Social tab of the Yoast metabox in an `og:image` tag</li><li>A user-defined “Featured image” for the page (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>A prominent image from the page’s content. (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>Yoast SEO WooCommerce only: Woo SEO adds one more image fallback: the first image in the Woo Product gallery.  (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>The “Social default image” from the template in Search Appearance in an `og:image` tag</li><li>The site-wide Social default image from SEO > Social in an `og:image` tag</li><li>No output.</li></ul> In case of an author archive, the image is based on the following hierarchy: <ul><li>The “Social default image” from the template in Search Appearance in an `og:image` tag</li><li>The user’s Gravatar image (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>No output, i.e. falls back to `og:image`.</li></ul> |
+| twitter:creator | The X handle of the content author. | Only populated when the content author has a valid X handle. <br /> Only populated on `post` types. |
+| twitter:title | The title of the page, specifically for sharing on X. | Only populated when a specific value (which is different from the `og:title` value) is defined for X. |
+| twitter:description | The description of the page, specifically for sharing on X. | Only populated when a specific value (different from the `og:description` value) is defined for X. <br /> <br /> The hierarchy for this is as follows: <ul><li>A user-defined "X description" value for the page.</li><li>An auto-generated "Social description" from the template in Search Appearance.</li><li>No output, i.e. falls back on `og:description`.</li></ul> |
+| twitter:image | The URL of the primary image of the page, specifically for sharing on X. | Only populated when a specific image (different from the `og:image`) is defined for X, or, when Facebook / `og:image` tags are disabled. <br /> <br /> <ul><li>A user-defined “X image” in the Social tab of the Yoast metabox in a `twitter:image` tag</li><li>A user-defined “Facebook image” in the Social tab of the Yoast metabox in an `og:image` tag</li><li>A user-defined “Featured image” for the page (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>A prominent image from the page’s content. (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>Yoast SEO WooCommerce only: Woo SEO adds one more image fallback: the first image in the Woo Product gallery.  (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>The “Social default image” from the template in Search Appearance in an `og:image` tag</li><li>The site-wide Social default image from SEO > Social in an `og:image` tag</li><li>No output.</li></ul> In case of an author archive, the image is based on the following hierarchy: <ul><li>The “Social default image” from the template in Search Appearance in an `og:image` tag</li><li>The user’s Gravatar image (in an  `og:image` tag, or in a `twitter:image` tag if Open Graph is disabled)</li><li>No output, i.e. falls back to `og:image`.</li></ul> |
 
 ## "Enhanced Slack sharing" tags
-We utilize Twitter's "label/data" meta tag format to add additional data, which is shown when sharing URLs on Slack.
+We utilize X's "label/data" meta tag format to add additional data, which is shown when sharing URLs on Slack.
 Note that this should only be output if the "Enhanced Slack sharing" setting is enabled for the site.
 
 | Tag | Description | Notes |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,7 +28,7 @@ Learn how our features work, how to customize the outputs, and how best to integ
   - [Canonical URLs](features/seo-tags/canonical-urls/)
   - [Meta robots tags](features/seo-tags/meta-robots/overview.md)
 - [OpenGraph tags](features/opengraph/)
-- [Twitter tags](features/twitter/functional-specification.md)
+- [X tags](features/twitter/functional-specification.md)
 - [Schema.org markup](features/schema/)
   - [Schema pieces](/features/schema/pieces/)
   - [Output per plugin](/features/schema/plugins/)


### PR DESCRIPTION
Fixes https://github.com/Yoast/reserved-tasks/issues/207

## Summary
<!-- What does this PR change/introduce? -->
* Renames most Twitter references in documentation to X, to accompany https://github.com/Yoast/reserved-tasks/issues/115

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:

**Homepage (overview)**
* Confirm that `Twitter tags` have become `X tags`:
![image](https://github.com/Yoast/developer/assets/12400734/9a579a26-5e2d-4ccd-a0fa-d6969ca66605)
---
**Metadata API**
* Confirm that `Twitter presenters` have become `X presenters`:
![image](https://github.com/Yoast/developer/assets/12400734/0b2f75b3-f7b6-4cf5-b6a7-b12baf047bf3)
---
**Rest API**
* Confirm that in the example output, we have `x.com` in the **sameAs** attributes:
![image](https://github.com/Yoast/developer/assets/12400734/cace8404-56db-4774-a497-3462658a0c2a)
![image](https://github.com/Yoast/developer/assets/12400734/fc691343-d3f4-4775-af5d-62f1880a38a7) 
---
**Surfaces API**
* Confirm that all `Twitter` references in variable descriptions have become `X` references:
![image](https://github.com/Yoast/developer/assets/12400734/65469a6a-44bf-4a48-9c3b-733f07d44805)
---
**Deprecated filters and actions**
* Confirm that `Twitter image` is called now `X image`:
![image](https://github.com/Yoast/developer/assets/12400734/f45f4512-c3f3-4e68-9d53-0f3bd83f00c3)
---
**Integrating Yoast SEO**
* Confirm that `Twitter tags` have become `X tags`:
![image](https://github.com/Yoast/developer/assets/12400734/dcdb631a-f08f-4df6-b6ce-cdb761050602)
---
**Controls - Overview**
* Confirm that all `Twitter` references in the options descriptions have become `X` references:
![image](https://github.com/Yoast/developer/assets/12400734/60458ce4-b1a8-4a6a-ac0a-c99c6a5bcae2)
---
**Schema - Specification**
* Confirm that the `Twitter` reference in the **Other consumers** section has become an `X` reference:
![image](https://github.com/Yoast/developer/assets/12400734/6b0db12c-48f1-48c0-b45c-73b2b33343f6)
* also confirm that in the three examples, of the **Company Homepage**, the **article, with an author, on a company website** and the **product in a WooCommerce store**, we show `x.com` in the **sameAs** attributes.
![image](https://github.com/Yoast/developer/assets/12400734/f2daec71-aa00-4854-9a4e-671bde6adf73)
---
**Schema - plugins - Yoast SEO for Shopify**
* Confirm that in the examples, of the core logic,  we show `x.com` in the **sameAs** attribute.
![image](https://github.com/Yoast/developer/assets/12400734/02b333e8-50bb-434e-bee1-99d4e4236c53)


---
**X feature**
* Confirm that the `Twitter` reference in the sidebar, under Yoast SEO features has become an `X` reference:
![image](https://github.com/Yoast/developer/assets/12400734/457bc05c-a8a9-4ed9-866d-a521658379de)
* Also confirm that the title has become now `Yoast SEO X Tags: Functional specification`
![image](https://github.com/Yoast/developer/assets/12400734/90e8c36c-9689-4163-b3b0-846b6e7a2a87)
* And following are all the `Twitter` references that have become `X` references (highlighted by the browser search, to help identification):
![image](https://github.com/Yoast/developer/assets/12400734/8fd7d6da-6f62-482d-ae8b-a11447ae09c4)
![image](https://github.com/Yoast/developer/assets/12400734/996840eb-5830-4d3e-8a87-0033bb579328)

Note, the `A user-defined "X description" value for the page.` and `A user-defined “Facebook image” in the Social tab of the Yoast metabox in an og:image tag` changes and be critical of them. 

 
## Quality assurance
* [ ] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
