### PR TITLE
The key "type" must start with "@"

### DIFF
--- a/docs/features/schema/integration-guidelines.md
+++ b/docs/features/schema/integration-guidelines.md
@@ -75,7 +75,7 @@ class Book  {
 		$post_id = YoastSEO()->meta->for_current_page()->post_id;
 
 		// Set the type.
-		$data['type'] = 'Book';
+		$data['@type'] = 'Book';
 
 		// Give it a unique ID, based on the URL and the Post ID.
 		$data['@id'] = $canonical . '#/book/' . $post_id;


### PR DESCRIPTION
This example doesn't work properly.

`$data['type']` must be `$data['@type']`.