### PR TITLE
Fixes typo in integration-guidelines.md

### DIFF
--- a/docs/features/schema/integration-guidelines.md
+++ b/docs/features/schema/integration-guidelines.md
@@ -75,7 +75,7 @@ class Book  {
 		$post_id = YoastSEO()->meta->for_current_page()->post_id;
 
 		// Set the type.
-		$data['type'] = 'Book';
+		$data['@type'] = 'Book';
 
 		// Give it a unique ID, based on the URL and the Post ID.
 		$data['@id'] = $canonical . '#/book/' . $post_id;


### PR DESCRIPTION
Fixes https://github.com/Yoast/developer/issues/305

## Summary
Fixes a typo on our integration guidelines for schema. 

## Relevant technical choices
None.

## Test instructions
This PR can be acceptance tested by following these steps:
1. Go to `features/schema/integration-guidelines/`.
2. Confirm that `$data['type'] = 'Book';` is now `$data['@type'] = 'Book';`.

## Quality assurance
* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

