### PR TITLE
Explain Shopify blog post author schema id

### DIFF
--- a/docs/shopify/integrations/schema.md
+++ b/docs/shopify/integrations/schema.md
@@ -119,6 +119,7 @@ All pieces in our schema output can referenced via an `@id` attribute. To replic
 * `WebSite`: `shop.url | append: '/#/schema/website/1'`
 * `WebPage`: `canonical_url`
 * `Article`: `canonical_url | append: '#/schema/article/' | append: article.id`
+* `Person`: `article.author | handleize | prepend: '/#/schema/person/' | prepend: shop.url`
 * `Product`: `canonical_url | append: "/#/schema/Product"`
 * `Offer`: `shop.url | append: '/#/schema/Offer/' | append: variant.id`
 * `BreadcrumbList`: `canonical_url | append: '/#/schema/breadcrumb'`


### PR DESCRIPTION
## Summary
<!-- What does this PR change/introduce? -->

Explain how to reproduce the schema id for a Shopify blog post author.

## Relevant technical choices
Technical choices that affect more than this issue:

Took a shortcut in the explainer to keep the oneliner examples.

## Test instructions
This PR can be acceptance tested by following these steps:
1. Copy the code from `/shopify/integrations/schema-graph/`.
1. In your Shopify store add it to a "Custom Liquid" block on an article layout
1. Check the generated output matches the `@id` in the Yoast schema output

## Quality assurance
* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [x] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [x] Automated tests - I have added unit tests to verify the code works as intended.
* [x] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
