### PR TITLE
Remove the limitation that is fixed with 25.7

### DIFF
--- a/docs/features/llms-txt/functional-specification.md
+++ b/docs/features/llms-txt/functional-specification.md
@@ -33,7 +33,6 @@ This documentation explains how [Yoast SEO](https://yoast.com/wordpress/plugins/
 - We do not yet support markdown code blocks with special markdown characters. Currently these characters will be escaped. For example:
   - The site tagline contains the following string: “This is \`the *tagline\`”
   - llms.txt will output that as “This is \\\`the \\*tagline\\\`“
-- When you make any changes in the settings of the page selection while the feature is already enabled, these changes will be applied the next time an llms.txt file is generated. This will happen within a week.
 
 ## Filters
 


### PR DESCRIPTION
> [!NOTE]  
> To be merged when 25.7 is released.

## Summary
<!-- What does this PR change/introduce? -->
* Removes a known limitation that is no longer with the release of Free 25.7.

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:
* Go to the llms.txt page
* Confirm that in the **Known Limitation** section, you dont see the following limitation anymore:
> When you make any changes in the settings of the page selection while the feature is already enabled, these changes will be applied the next time an llms.txt file is generated. This will happen within a week.


## Quality assurance
* [ ] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
