### PR TITLE
Fix mermaid flowchart syntax in Indexables technical specification

### DIFF
--- a/docs/features/indexables/technical-specification.md
+++ b/docs/features/indexables/technical-specification.md
@@ -24,26 +24,26 @@ considered indexable objects. Of course a post has to _exist_ to be a valid Inde
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': { 'edgeLabelBackground':'#ffffff', 'stroke':'#000'}}}%%
- flowchart TD
+flowchart TD
   Input([Post]) --> PTRegistered{Post <em>type</em> registered?}
-  PTRegistered == Yes ==>PTExcluded{Post <em>type</em> excluded<br/><a href='/features/indexables/indexables-filters/#post_types'>through filter</a>?}
-  PTRegistered -- No -->NoIndexable([Do <strong>not</strong> create an indexable])
-  PTExcluded -- Yes -->PTIncluded{Post <em>type</em> force included<br/><a href='/features/indexables/indexables-filters/#included_post_types'>through filter</a>?}
-  PTExcluded == No ==>PTPublic{Is the<br/>post <em>type</em> <code>public</code>?}
-  PTPublic == Yes ==>PTAttachment{Is the post<br/><em>type</em> <code>attachment</code>?}
-  PTPublic == No ==>PTIncluded
-  PTAttachment -- Yes -->AttDisabled{Are <a href='https://yoast.com/features/redirect-attachment-urls/'>attachment URLs<br/> disabled</a> in Yoast SEO?}
-  AttDisabled -- Yes -->PTIncluded
-  AttDisabled == No ==>PSRegistered{Post <em>status</em> registered?}
-  PTAttachment == No ==>PSRegistered
-  PSRegistered -- No -->NoIndexable
-  PSRegistered == Yes ==>PSPublic{Is the post<br/><em>status</em> <code>public</code>?}
-  PSPublic -- No -->IncludedNonPublishPostStatus{Post <em>status</em> one of:<br/><code>draft</code>, <code>pending</code>, <code>future</code>?}
-  PTIncluded == No -->NoIndexable
-  PTIncluded == Yes -->CreateIndexable
-  IncludedNonPublishPostStatus -- No -->NoIndexable
-  IncludedNonPublishPostStatus == Yes ==>CreateIndexable
-  PSPublic == Yes ==>CreateIndexable([Create an indexable])
+  PTRegistered -- Yes --> PTExcluded{Post <em>type</em> excluded<br/><a href='/features/indexables/indexables-filters/#post_types'>through filter</a>?}
+  PTRegistered -- No --> NoIndexable([Do <strong>not</strong> create an indexable])
+  PTExcluded -- Yes --> PTIncluded{Post <em>type</em> force included<br/><a href='/features/indexables/indexables-filters/#included_post_types'>through filter</a>?}
+  PTExcluded -- No --> PTPublic{Is the<br/>post <em>type</em> <code>public</code>?}
+  PTPublic -- Yes --> PTAttachment{Is the post<br/><em>type</em> <code>attachment</code>?}
+  PTPublic -- No --> PTIncluded
+  PTAttachment -- Yes --> AttDisabled{Are <a href='https://yoast.com/features/redirect-attachment-urls/'>attachment URLs<br/> disabled</a> in Yoast SEO?}
+  AttDisabled -- Yes --> PTIncluded
+  AttDisabled -- No --> PSRegistered{Post <em>status</em> registered?}
+  PTAttachment -- No --> PSRegistered
+  PSRegistered -- No --> NoIndexable
+  PSRegistered -- Yes --> PSPublic{Is the post<br/><em>status</em> <code>public</code>?}
+  PSPublic -- No --> IncludedNonPublishPostStatus{Post <em>status</em> one of:<br/><code>draft</code>, <code>pending</code>, <code>future</code>?}
+  PTIncluded -- No --> NoIndexable
+  PTIncluded -- Yes --> CreateIndexable([Create an indexable])
+  IncludedNonPublishPostStatus -- No --> NoIndexable
+  IncludedNonPublishPostStatus -- Yes --> CreateIndexable
+  PSPublic -- Yes --> CreateIndexable
   style Input fill:#ddf,stroke:#aaf,stroke-width:2px
   style NoIndexable fill:#ffcccc,stroke:#f00,stroke-width:2px
   style CreateIndexable fill:#ccffcc,stroke:#0f0,stroke-width:2px


### PR DESCRIPTION
There are two syntax issues with the first mermaid diagram - a mix-up between `==` and `--` syntax within a single directional relation.

<img width="1543" height="694" alt="image" src="https://github.com/user-attachments/assets/966dfc66-a9a2-48a3-b91d-0579cad94927" />

I assume this worked before but now broke because the validation in the mermaid parser became stricter.

Given that I don't know what purpose the differentiation between `-->` and `==>` was supposed to signify (and it does not come with any legend to this regard), I opted to just strip all `==>` (bold) relations and consistently use `-->` throughout the diagram.

## Summary
Replaces all the different types of arrows with a consistent `-->` (single-dash) syntax.

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:
1. First diagram should render correctly at https://developer.yoast.com/features/indexables/technical-specification/

## Quality assurance
* [ ] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
