### PR TITLE
Update the woo seo documentation to make sure we mention the change in schema behavior.

### DIFF
--- a/docs/features/schema/plugins/woocommerce-seo.md
+++ b/docs/features/schema/plugins/woocommerce-seo.md
@@ -12,7 +12,7 @@ The schema output for our [WooCommerce SEO plugin](https://yoast.com/wordpress/p
 * Remove WooCommerce's breadcrumb schema.
 
 ### On product pages
-* Change the `@type` of the `WebPage` piece into `ItemPage`. While taking into account additional types added via the [schema API](../api.md).
+* Change the `@type` of the `WebPage` piece into `ItemPage`, while taking into account additional types added via the [schema API](../api.md).
 * Alter the `Product` piece.
   * Apply our validation logic to each existing WooCommerce *piece* /value.
   * Add a `mainEntityOfPage` property to the `Product`, referencing the `WebPage` by ID.

--- a/docs/features/schema/plugins/woocommerce-seo.md
+++ b/docs/features/schema/plugins/woocommerce-seo.md
@@ -12,7 +12,7 @@ The schema output for our [WooCommerce SEO plugin](https://yoast.com/wordpress/p
 * Remove WooCommerce's breadcrumb schema.
 
 ### On product pages
-* Change the `@type` of the `WebPage` piece into `ItemPage`.
+* Change the `@type` of the `WebPage` piece into `ItemPage`. While taking into account additional types added via the [schema API](../api.md).
 * Alter the `Product` piece.
   * Apply our validation logic to each existing WooCommerce *piece* /value.
   * Add a `mainEntityOfPage` property to the `Product`, referencing the `WebPage` by ID.


### PR DESCRIPTION
We changed the @type change so that when a filter adds a type it keeps the type besides changing WebPage to ItemPage. For example is you add a FAQ block, we also add FAQPage to the schema.

This is a companion to https://github.com/Yoast/wpseo-woocommerce/pull/1084
## Summary
<!-- What does this PR change/introduce? -->

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:
1.
1.
1.

## Quality assurance
* [ ] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
