### PR TITLE
fix(rc-docs-sync): grant id-token: write for Claude Code Action OIDC

### DIFF
--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -45,6 +45,7 @@ permissions:
   contents: write       # push per-RC doc branches (NOT main — main is protected)
   pull-requests: write  # open and label PRs
   issues: write         # comment on tracking issue(s)
+  id-token: write       # required by anthropics/claude-code-action for OIDC auth
 
 jobs:
   # =====================================================================


### PR DESCRIPTION
## What

Adds `id-token: write` to the `rc-docs-sync.yml` workflow's permissions block.

## Why

The first manual dispatch ([run #25058854766](https://github.com/Yoast/developer/actions/runs/25058854766)) failed at the agent step:

> Could not fetch an OIDC token. Did you remember to add \`id-token: write\` to your workflow permissions?

`anthropics/claude-code-action@v1` uses OIDC to authenticate to Anthropic alongside the API key, which requires `id-token: write` on the calling workflow.

## Risk

Minimal — the permission is scoped to letting the workflow request its own OIDC token; doesn't change anything about which repos/issues/PRs the workflow can touch. All other permissions (`contents/pull-requests/issues`) unchanged.

## Validation

After merging, re-run `workflow_dispatch` with `product=wordpress-seo` and `rc_tag=27.6-RC1` (or another past RC) — the agent step should now reach Anthropic's API.