### PR TITLE
Add src/ai/** to the AI area's wordpress-seo source paths

### DIFF
--- a/AGENT_MAP.md
+++ b/AGENT_MAP.md
@@ -173,7 +173,7 @@ No currently-listed product has more than one source repo. If one is ever added 
 ### `ai`
 - **Products**: wordpress-seo, wordpress-seo-premium
 - **Docs paths**: `docs/features/ai/**`
-- **Source paths** (wordpress-seo): `src/ai-*/**`, `src/generators/ai*`, `src/integrations/ai*`
+- **Source paths** (wordpress-seo): `src/ai/**` (current convention — all new AI feature code lives here), `src/ai-*/**` (legacy, being migrated under `src/ai/`; safe to drop once the migration completes), `src/generators/ai*`, `src/integrations/ai*`
 - **Source paths** (wordpress-seo-premium): `src/ai/**`
 - **Symbol namespaces**: `wpseo_ai_*`
 - **Typical triggers**: new AI error code; new AI feature exposing a filter; change to request/retry behavior documented in `ai-errors.md`.


### PR DESCRIPTION
## What

One-line update to `AGENT_MAP.md`: adds `src/ai/**` to the `ai` area's wordpress-seo source paths and flags `src/ai-*/**` as the legacy convention that's being migrated away from.

```diff
- **Source paths** (wordpress-seo): `src/ai-*/**`, `src/generators/ai*`, `src/integrations/ai*`
+ **Source paths** (wordpress-seo): `src/ai/**` (current convention — all new AI feature code lives here), `src/ai-*/**` (legacy, being migrated under `src/ai/`; safe to drop once the migration completes), `src/generators/ai*`, `src/integrations/ai*`
```

## Why

The agent surfaced this as a real coverage gap on its 27.6-RC2 run ([workflow run](https://github.com/Yoast/developer/actions/runs/25102184836), tracking comment on issue #390):

> The `ai` area in AGENT_MAP.md lists `src/ai-*/**` as its source path (hyphenated prefix), which matches `src/ai-generator/` etc. but does **not** match the new `src/ai/` directory (non-hyphenated). All new Content Planner PHP lives under `src/ai/content-planner/`, outside every area's `source_paths`.

This adopts that recommendation while also recording the migration context so future readers (and a future maintainer reviewing the area) know that the legacy `src/ai-*/**` glob is transitional and can be removed once `Yoast/wordpress-seo`'s migration to `src/ai/` is complete.

The Premium row already had `src/ai/**` for unrelated reasons; this just brings the Free row into line with the new directory naming convention.

## Risk

None. The only consumer of these globs is the agent's triage step; widening the area's coverage cannot cause it to miss things, only to consider more files for AI-area attribution. The legacy `src/ai-*/**` glob is preserved, so any files still living under `src/ai-generator/`, `src/ai-authorization/`, etc. continue to be matched.