### PR TITLE
Diff iterative RCs against the prior RC of the same base version

### DIFF
--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -107,13 +107,20 @@ jobs:
               cp = subprocess.run(["gh"] + args, check=True, capture_output=True, text=True)
               return json.loads(cp.stdout)
 
-          def fetch_latest_marker(issue_number, product_slug):
+          def fetch_processed_markers(issue_number, product_slug):
+              """Return list of RC tags processed for this product, in the document order
+              they appear in the tracking issue's comments (oldest first)."""
               data = gh_json(["issue", "view", str(issue_number), "--json", "comments"])
-              for c in reversed(data.get("comments", [])):
+              out = []
+              for c in data.get("comments", []):
                   for m in MARKER_RE.finditer(c.get("body", "")):
                       if m.group("product") == product_slug:
-                          return m.group("rc_tag")
-              return None
+                          out.append(m.group("rc_tag"))
+              return out
+
+          def base_version(tag):
+              """Strip the -RC<n> suffix from a tag. 27.6-RC2 -> 27.6; 27.1.1-RC3 -> 27.1.1."""
+              return re.sub(r"-RC\d+$", "", tag)
 
           def fetch_tags(repo):
               url = f"https://api.github.com/repos/{repo}/tags?per_page=100"
@@ -140,13 +147,14 @@ jobs:
               rc_tags = [t for t in all_tags if RC_TAG_RE.match(t)]
               stable_tags = [t for t in all_tags if STABLE_RE.match(t)]
 
+              processed_markers = fetch_processed_markers(tracking_issue, slug)
+
               if input_rc_tag and input_product == slug:
                   if input_rc_tag not in rc_tags:
                       print(f"{input_rc_tag} not found as RC in {main_repo}", file=sys.stderr); sys.exit(2)
                   rcs_to_process = [input_rc_tag]
               else:
-                  last = fetch_latest_marker(tracking_issue, slug)
-                  if last is None:
+                  if not processed_markers:
                       rc_tags_sorted = sorted(rc_tags, key=sort_key)
                       seed_rc = rc_tags_sorted[-1] if rc_tags_sorted else None
                       if seed_rc:
@@ -155,20 +163,40 @@ jobs:
                               "rc_tag": seed_rc, "display_name": product["display_name"],
                           })
                       continue
-                  last_key = sort_key(last)
+                  last_key = sort_key(processed_markers[-1])
                   rcs_to_process = sorted([t for t in rc_tags if sort_key(t) > last_key], key=sort_key)
 
               for rc_tag in rcs_to_process:
-                  prev_candidates = [t for t in stable_tags if sort_key(t) <= sort_key(rc_tag)]
-                  if not prev_candidates:
-                      print(f"no previous stable for {rc_tag}; skipping", file=sys.stderr); continue
-                  prev = sorted(prev_candidates, key=sort_key)[-1]
+                  # Prefer the most recent already-processed RC of the same base version as
+                  # the diff base — that way iterative RCs (RC2, RC3, ...) only see the
+                  # incremental delta from the last RC, not the whole release cycle.
+                  # Falls back to the latest stable release before this RC when no prior
+                  # same-base RC has been processed (first RC of a new base, or backfill
+                  # against an RC older than anything previously processed).
+                  base = base_version(rc_tag)
+                  same_base_processed = [
+                      t for t in processed_markers
+                      if base_version(t) == base
+                      and t != rc_tag
+                      and sort_key(t) < sort_key(rc_tag)
+                  ]
+                  if same_base_processed:
+                      prev = sorted(same_base_processed, key=sort_key)[-1]
+                      prev_kind = "rc"
+                  else:
+                      prev_candidates = [t for t in stable_tags if sort_key(t) <= sort_key(rc_tag)]
+                      if not prev_candidates:
+                          print(f"no previous stable for {rc_tag}; skipping", file=sys.stderr); continue
+                      prev = sorted(prev_candidates, key=sort_key)[-1]
+                      prev_kind = "stable"
+
                   queue.append({
                       "product": slug,
                       "display_name": product["display_name"],
                       "repos": product["repos"],
                       "rc_tag": rc_tag,
                       "prev_release": prev,
+                      "prev_kind": prev_kind,
                       "tracking_issue": tracking_issue,
                   })
 
@@ -307,6 +335,7 @@ jobs:
           BUNDLE_DIR: ${{ github.workspace }}/${{ steps.bundle.outputs.bundle_dir }}
           TRACKING_ISSUE: ${{ matrix.item.tracking_issue }}
           PREV_RELEASE: ${{ matrix.item.prev_release }}
+          PREV_KIND: ${{ matrix.item.prev_kind }}  # 'stable' or 'rc' — see Resolve work queue
           GH_REPO: ${{ github.repository }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
@@ -324,7 +353,7 @@ jobs:
             - `DISPLAY_NAME` (e.g. `Yoast SEO`)
             - `BUNDLE_DIR` — absolute path to this run's bundle directory; contains `rc.diff.filtered`, `rc.diff.full`, `rc.diff.stat`, `changelog.source`, `symbol-index.txt`, organized as `$BUNDLE_DIR/<source-repo>/...`.
             - `TRACKING_ISSUE` — numeric issue id where the run-summary comment must be posted.
-            - `PREV_RELEASE` — the source-repo tag the diff was computed against.
+            - `PREV_RELEASE` — the source-repo tag the diff was computed against. May be a stable release (e.g. `27.5`) or a prior RC of the same base version (e.g. `27.6-RC1`); `PREV_KIND` is `stable` or `rc` accordingly. When it's `rc`, expect the diff to be small (incremental delta vs. the previous RC of this cycle); when it's `stable`, the diff is the full release cycle.
             - `WORKFLOW_RUN_URL` — link to this workflow run; include in the PR body for reviewer context.
 
             When the prompt instructs you to post comments or create PRs, use `gh` (already authenticated). When it instructs you to read the source diff, look in `$BUNDLE_DIR/<repo-name>/`.


### PR DESCRIPTION
## What

Changes the diff-base resolution in `.github/workflows/rc-docs-sync.yml` so that iterative RCs (e.g. `27.6-RC2`, `27.6-RC3`, ...) are diffed against the most recent already-processed RC of the same base version, rather than always against the latest stable release.

## Why

The 27.6-RC2 run on Tuesday cost **\$2.10** for a single processing pass:

> ```json
> { "duration_ms": 476352, "num_turns": 64, "total_cost_usd": 2.10 }
> ```

…because the diff was `27.5..27.6-RC2` — 62k lines covering essentially the entire 27.6 release cycle, the vast majority of which was already considered (and rejected as internal) when 27.6-RC1 was processed. Every RC iteration in a cycle redoes the same work.

This was already noted as a known optimization in [#394](https://github.com/Yoast/developer/pull/394)'s body. Implementing it now.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `27.6-RC1` (first RC of cycle) | diff vs. `27.5` | diff vs. `27.5` (unchanged) |
| `27.6-RC2` (after RC1 processed) | diff vs. `27.5` | **diff vs. `27.6-RC1`** |
| `27.6-RC3` (after RC2 processed) | diff vs. `27.5` | **diff vs. `27.6-RC2`** |
| `27.6` stable | not processed | not processed (unchanged) |
| `27.7-RC1` (new cycle, after `27.6` shipped) | diff vs. `27.6` | diff vs. `27.6` (unchanged) |
| Manual backfill of `27.6-RC2` (no prior `27.6` markers) | diff vs. `27.5` | diff vs. `27.5` (unchanged) |
| Manual backfill of `27.6-RC2` (markers for RC1 + RC3 already exist) | diff vs. `27.5` | diff vs. `27.6-RC1` |

The first-run seed behavior, the manual-`workflow_dispatch` explicit-RC path, and the agent's overall flow are all unchanged. The optimization fires automatically wherever prior same-base-version RCs are recorded on the tracking issue.

## Implementation

- `fetch_latest_marker` → `fetch_processed_markers`. Returns the full list of processed RC tags for a product instead of just the most recent. Both the cron's "what's newer than the marker" gate and the new diff-base resolver now share one API call and one helper.
- Per-RC loop adds a "prefer same-base prior RC" branch before the existing "fall back to latest stable" branch.
- Added `PREV_KIND` env var (`stable` or `rc`) alongside the existing `PREV_RELEASE` so the agent can mention in its run summary whether this run was a full-cycle diff or an incremental-RC diff. Optional context; the prompt doesn't require it.

## Expected cost impact

For Yoast SEO's bi-weekly cadence (≈26 cycles/year), assuming an average of 2 RC iterations per cycle:

- **Today (this PR not in)**: ~52 RC tags/year × ~$2 each =  ~$100/year for free alone.
- **With this PR**: ~26 first-RCs at ~$2 + ~26 iterative RCs at ~$0.10 (small delta diffs) ≈ ~$55/year for free alone.

About a 2× reduction on free, more on full rollout because every product's iterative RCs benefit. Also drops PR-noise risk: the agent re-considers only what's actually new since the previous RC, rather than re-evaluating the same already-decided content.

## Risk

Low. The fallback path is unchanged, so any RC for which no prior same-base marker exists behaves exactly like today. Manual `workflow_dispatch` with an explicit `rc_tag` continues to work, and `fetch_processed_markers` is a strict superset of what `fetch_latest_marker` returned, so the cron's "newer than last processed" gate is unaffected.

The one observable change is that PRs opened on iterative RCs will reference a smaller, narrower diff in their evidence — which is what we want.