### PR TITLE
docs(installation): rewrite Composer install guide

### DIFF
--- a/docs/development/installation/using-composer.md
+++ b/docs/development/installation/using-composer.md
@@ -4,42 +4,54 @@ title: "Yoast SEO: Install using Composer"
 sidebar_label: Using Composer
 ---
 
-## What is Composer?
-[Composer](https://getcomposer.org/) is a dependency manager tool for PHP projects (similar to NPM) and can be run from your terminal.
+[Composer](https://getcomposer.org/) is the PHP dependency manager. If you run a Composer-managed WordPress site, you can pull Yoast SEO and Yoast SEO Premium in as Composer dependencies.
 
-## Installing Composer
+Working on Yoast SEO itself rather than consuming it? See the [contributor setup](/development/environment/setup) instead.
 
-To get Composer installed on your system, make sure you follow the [official installation steps](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos).
+## Requirement: your project must register a Composer autoloader
 
-## Installing Yoast SEO via Composer
-To install Yoast SEO via Composer, run the following command in your `plugins` directory:
+The Composer-distributed Yoast SEO package does not ship its own `vendor/autoload.php`. Yoast SEO's classes are loaded through your project's root autoloader, which must be registered before WordPress loads plugins. In practice this means a line equivalent to:
 
-```shell script
+```php
+require_once __DIR__ . '/vendor/autoload.php';
+```
+
+before `require ABSPATH . 'wp-settings.php';` runs. Most Composer-managed WordPress stacks already do this; if yours doesn't, add it (in `wp-config.php`, in your scaffold's pre-WP bootstrap file, or via a small must-use plugin).
+
+If no autoloader is registered, Yoast SEO will detect this on the first admin request, display a *"plugin installation is incomplete"* notice and self-deactivate.
+
+## Yoast SEO (free)
+
+From the **root of your Composer-managed WordPress project**:
+
+```shell
 composer require yoast/wordpress-seo
-``` 
+```
 
-The command above downloads the latest version of the Yoast SEO plugin and installs all necessary dependencies.
+The package is routed to `wp-content/plugins/wordpress-seo/`.
 
-## Installing a development version of Yoast SEO
-If you are looking to help develop Yoast SEO (i.e. patch a bug, for example), we recommend you use `git clone git@github.com:Yoast/wordpress-seo.git` as we don't support downloading development versions of Yoast SEO through Composer.
+## Yoast SEO Premium
 
-## Post-installation
-Once Composer has completed its installation process, or git is done cloning the repository, please make sure you run `yarn`, followed by `grunt:build` in the `wordpress-seo` directory to ensure all necessary files are properly built.
+Premium is distributed via Yoast's private Composer repository at `https://my.yoast.com/packages/`. You will need a Composer install token from your MyYoast account.
 
-## Updating dependencies
+```shell
+composer config -g http-basic.my.yoast.com token <your-token>
+composer config repositories.my-yoast composer https://my.yoast.com/packages/
+composer require yoast/wordpress-seo-premium
+```
 
-Composer tracks the state of the project in the `composer.lock` file. Running `composer install` will always reproduce that state, ensuring consistency across developers' setups.
-When dependencies need to be updated the following command will bring said dependencies to the latest versions, as far as is allowed by the version restrictions set in `composer.json`.
+This installs both Premium and the free plugin (which Premium depends on) into `wp-content/plugins/`. Premium relies on the same project-level autoloader as the free plugin — see the [requirement](#requirement-your-project-must-register-a-composer-autoloader) above.
 
-```shell script
+## Updating
+
+```shell
 composer update
 ```
 
-After that, the updated `composer.lock` file needs to be committed into version control.
+Composer tracks the resolved state in `composer.lock`. Commit `composer.lock` so every environment installs the same versions.
 
 :::caution
 
-Please note that updating dependencies is somewhat of a delicate process and doing so might result in breakage. 
-Always properly test before committing an updated version of `composer.json` and `composer.lock`. 
+Updating Composer dependencies is a delicate process and may introduce regressions. Always test before committing an updated `composer.json` / `composer.lock`.
 
 :::

--- a/docs/development/installation/using-composer.md
+++ b/docs/development/installation/using-composer.md
@@ -20,7 +20,7 @@ before `require ABSPATH . 'wp-settings.php';` runs. Most Composer-managed WordPr
 
 If no autoloader is registered, Yoast SEO will detect this on the first admin request, display a *"plugin installation is incomplete"* notice and self-deactivate.
 
-## Yoast SEO (free)
+## Yoast SEO
 
 From the **root of your Composer-managed WordPress project**:
 
@@ -40,7 +40,7 @@ composer config repositories.my-yoast composer https://my.yoast.com/packages/
 composer require yoast/wordpress-seo-premium
 ```
 
-This installs both Premium and the free plugin (which Premium depends on) into `wp-content/plugins/`. Premium relies on the same project-level autoloader as the free plugin — see the [requirement](#requirement-your-project-must-register-a-composer-autoloader) above.
+This installs Yoast SEO Premium and Yoast SEO (which Premium depends on) into `wp-content/plugins/`. Premium relies on the same project-level autoloader as Yoast SEO — see the [requirement](#requirement-your-project-must-register-a-composer-autoloader) above.
 
 ## Updating
 


### PR DESCRIPTION
Refs Yoast/wordpress-seo#22545

## Summary

The current Composer install page tells integrators to run `composer require` from inside the `plugins/` directory (which produces an incorrect install path through `composer/installers`) and claims the published package "installs all necessary dependencies". In practice the Composer-distributed artifact is source-style: it does not include `vendor/autoload.php`, and Yoast SEO's classes are reached through the consumer project's root autoloader. Composer-managed WP setups that don't register an autoloader before plugins load (a common case on stacks where `wp-config.php` is platform-supplied) end up with a broken install — see Yoast/wordpress-seo#22545.

This rewrite restructures the page around that requirement, separates the free and Premium flows, documents the MyYoast token + repository setup for Premium, and folds the contributor-only `yarn` / `grunt build` steps out of the install guide into a single link to the contributor setup.

## Relevant technical choices

- The opening section makes the autoloader requirement explicit and gives the canonical `require_once __DIR__ . '/vendor/autoload.php';` line, without prescribing where to put it (intentionally stack-agnostic).
- The Premium section uses the three-line token + repository + require flow that mirrors the Composer install instructions surfaced in MyYoast.
- The page still references the same `id: using-composer`, sidebar label, and headings file slug, so deep links and the sidebar entry remain unchanged.
- The "self-deactivate with a notice" sentence currently describes the free plugin's behaviour. It will also apply to Premium once the Premium-side bootstrap fix lands (companion change in `Yoast/wordpress-seo-premium`); if this PR ships first, the sentence may need to be softened to acknowledge that Premium currently fatals rather than deactivates.

## Test instructions

This PR can be acceptance tested by following these steps:

1. Run `yarn build` locally (or wait for CI's preview deploy) and open `docs/development/installation/using-composer.md` in the rendered Docusaurus site.
1. Confirm the page renders with the four sections (requirement, free, Premium, updating) and that the in-page anchor link from the Premium section back to "requirement" works.
1. Confirm the contributor-setup link at the top of the page still resolves to `/development/environment/setup`.

## Quality assurance

* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [x] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.