### PR TITLE
rc-docs-sync: pre-agent fast-path, strip version bumps, cover AI Content Planner JS

### DIFF
--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -333,9 +333,17 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          issue='${{ matrix.item.tracking_issue }}'
+          product='${{ matrix.item.product }}'
           rc_tag='${{ matrix.item.rc_tag }}'
           base_version="${rc_tag%-RC*}"
-          gh issue comment '${{ matrix.item.tracking_issue }}' --body "<!-- rc-docs-sync:v1 product=${{ matrix.item.product }} rc_tag=${rc_tag} -->
+          # Idempotency: skip if a marker for this (product, rc_tag) already exists.
+          if gh issue view "$issue" --json comments --jq '.comments[].body' \
+              | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${product}[[:space:]]+rc_tag=${rc_tag}[[:space:]]*-->"; then
+            echo "Marker for ${product} ${rc_tag} already on issue #${issue}; skipping no-op summary."
+            exit 0
+          fi
+          gh issue comment "$issue" --body "<!-- rc-docs-sync:v1 product=${product} rc_tag=${rc_tag} -->
 
           **${{ matrix.item.display_name }} ${base_version}** (RC \`${rc_tag}\`) — no doc changes needed.
           Filtered diff is empty (only tests/translations/lockfiles changed).
@@ -486,7 +494,19 @@ jobs:
           BUNDLE_DIR: ${{ github.workspace }}/${{ steps.bundle.outputs.bundle_dir }}
         run: |
           set -euo pipefail
-          gh issue comment '${{ matrix.item.tracking_issue }}' --body-file "${BUNDLE_DIR}/fast-path-comment.md"
+          issue='${{ matrix.item.tracking_issue }}'
+          product='${{ matrix.item.product }}'
+          rc_tag='${{ matrix.item.rc_tag }}'
+          # Idempotency: if a marker for this (product, rc_tag) already exists on the
+          # tracking issue (e.g. from a prior scheduled run, or a workflow_dispatch
+          # backfill), don't post a duplicate. Same dedup pattern as the safety-net
+          # step below.
+          if gh issue view "$issue" --json comments --jq '.comments[].body' \
+              | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${product}[[:space:]]+rc_tag=${rc_tag}[[:space:]]*-->"; then
+            echo "Marker for ${product} ${rc_tag} already on issue #${issue}; skipping fast-path comment."
+            exit 0
+          fi
+          gh issue comment "$issue" --body-file "${BUNDLE_DIR}/fast-path-comment.md"
 
       - name: Invoke Claude agent
         if: steps.bundle.outputs.any_content == 'true' && steps.detect.outputs.has_public_surface == 'true'

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -277,14 +277,15 @@ jobs:
             git -C "sources/${name}" diff "${{ matrix.item.prev_release }}..${{ matrix.item.rc_tag }}" > "${rb}/rc.diff.full"
             # `-I<regex>` drops hunks whose *every* changed line matches at least one
             # of the regexes. Used here to strip the per-RC version-string bumps
-            # (Version: header, WPSEO_VERSION define, "version": in package.json,
-            # CURRENT_RELEASE / MINIMUM_SUPPORTED constants) so the agent doesn't have
-            # to read them and dismiss them as noise each run. `rc.diff.full` keeps
-            # them as a cross-check.
+            # (PHP file header, WPSEO_VERSION define, package.json's "version" and
+            # "pluginVersion" fields, CURRENT_RELEASE / MINIMUM_SUPPORTED constants)
+            # so the agent doesn't have to read them and dismiss them as noise each
+            # run. `rc.diff.full` keeps them as a cross-check.
             git -C "sources/${name}" diff "${{ matrix.item.prev_release }}..${{ matrix.item.rc_tag }}" \
               -I' \* Version: ' \
               -I'WPSEO_VERSION' \
               -I'"version":' \
+              -I'"pluginVersion":' \
               -I'CURRENT_RELEASE' \
               -I'MINIMUM_SUPPORTED' \
               -- \

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -548,8 +548,13 @@ jobs:
             --max-turns 100
             --model claude-sonnet-4-6
 
+      # Safety net runs whenever the bundle was non-empty (any_content == 'true').
+      # The step body deduplicates: if any earlier step already posted the marker
+      # (the agent itself, or the fast-path marker step), it exits early. This
+      # also catches the edge case where the detect step crashes — the step body
+      # then sees no marker exists and posts the fallback.
       - name: Ensure marker comment exists (safety net)
-        if: always() && steps.bundle.outputs.any_content == 'true' && steps.detect.outputs.has_public_surface == 'true'
+        if: always() && steps.bundle.outputs.any_content == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -336,8 +336,155 @@ jobs:
           Filtered diff is empty (only tests/translations/lockfiles changed).
           Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      - name: Invoke Claude agent
+      # ---------------------------------------------------------------------
+      # Pre-agent fast-path: when the filtered diff is non-empty but contains
+      # no new public surface (no new register_rest_route / WP_CLI::add_command
+      # / apply_filters / do_action calls referencing undocumented symbols),
+      # post a "no doc changes" marker and skip the Claude agent invocation
+      # entirely. Catches the common case where a small RC contains only
+      # internal refactors / JS-only changes / version bumps.
+      #
+      # Risk: misses behavior-only changes that don't introduce new symbols.
+      # The agent prompt flags these as uncertain anyway; if this becomes a
+      # missed-doc source, tighten the heuristic or invoke the agent on a
+      # cheaper model as a spot-check.
+      # ---------------------------------------------------------------------
+      - name: Detect new public surface in filtered diff
+        id: detect
         if: steps.bundle.outputs.any_content == 'true'
+        env:
+          PRODUCT: ${{ matrix.item.product }}
+          RC_TAG: ${{ matrix.item.rc_tag }}
+          DISPLAY_NAME: ${{ matrix.item.display_name }}
+          BUNDLE_DIR: ${{ github.workspace }}/${{ steps.bundle.outputs.bundle_dir }}
+          PREV_RELEASE: ${{ matrix.item.prev_release }}
+          PREV_KIND: ${{ matrix.item.prev_kind }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import glob, os, re, sys
+
+          bundle_dir = os.environ['BUNDLE_DIR']
+          rc_tag = os.environ['RC_TAG']
+          display_name = os.environ['DISPLAY_NAME']
+          prev_release = os.environ['PREV_RELEASE']
+          prev_kind = os.environ['PREV_KIND']
+          product = os.environ['PRODUCT']
+          run_url = os.environ['WORKFLOW_RUN_URL']
+
+          # symbol-index.txt entries are quoted (e.g. 'wpseo_foo'); strip quotes.
+          symbol_index = set()
+          si_path = os.path.join(bundle_dir, "symbol-index.txt")
+          if os.path.exists(si_path):
+              with open(si_path) as f:
+                  for line in f:
+                      sym = line.strip().strip("'\"")
+                      if sym:
+                          symbol_index.add(sym)
+
+          HOOK_RE  = re.compile(r"(?:apply_filters|do_action)\s*\(\s*['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]")
+          ROUTE_RE = re.compile(r"register_rest_route\s*\(")
+          CLI_RE   = re.compile(r"WP_CLI::add_command\s*\(")
+
+          new_routes, new_cli, new_hook_symbols = [], [], set()
+          diff_files = sorted(glob.glob(os.path.join(bundle_dir, "*", "rc.diff.filtered")))
+          for path in diff_files:
+              with open(path) as f:
+                  for line in f:
+                      if not line.startswith('+') or line.startswith('+++'):
+                          continue
+                      body = line[1:]
+                      if ROUTE_RE.search(body):
+                          new_routes.append(body.strip())
+                      if CLI_RE.search(body):
+                          new_cli.append(body.strip())
+                      for m in HOOK_RE.finditer(body):
+                          sym = m.group(1)
+                          if sym not in symbol_index:
+                              new_hook_symbols.add(sym)
+
+          has_public = bool(new_routes or new_cli or new_hook_symbols)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as gho:
+              gho.write(f"has_public_surface={'true' if has_public else 'false'}\n")
+
+          if has_public:
+              print("Public surface detected — agent will be invoked.")
+              if new_routes:
+                  print(f"  new register_rest_route lines: {len(new_routes)}")
+                  for l in new_routes[:5]: print(f"    {l}")
+              if new_cli:
+                  print(f"  new WP_CLI::add_command lines: {len(new_cli)}")
+                  for l in new_cli[:5]: print(f"    {l}")
+              if new_hook_symbols:
+                  print(f"  new (undocumented) hook symbols: {sorted(new_hook_symbols)}")
+              sys.exit(0)
+
+          # No new public surface — assemble the fast-path comment body.
+          filtered_total = 0
+          stat_entries = []
+          STAT_RE = re.compile(r"^\s*(\S.*?)\s*\|\s*(\d+)")
+          for path in diff_files:
+              with open(path) as f:
+                  filtered_total += sum(1 for _ in f)
+              repo_name = os.path.basename(os.path.dirname(path))
+              stat_path = os.path.join(bundle_dir, repo_name, "rc.diff.stat")
+              if os.path.exists(stat_path):
+                  with open(stat_path) as f:
+                      for line in f:
+                          m = STAT_RE.match(line)
+                          if m:
+                              stat_entries.append((m.group(1), int(m.group(2))))
+          top = sorted(stat_entries, key=lambda p: -p[1])[:8]
+
+          base_version = re.sub(r"-RC\d+$", "", rc_tag)
+          prev_desc = "incremental RC delta" if prev_kind == "rc" else "full release cycle vs. stable"
+
+          body = [
+              f"<!-- rc-docs-sync:v1 product={product} rc_tag={rc_tag} -->",
+              f"## {display_name} {base_version}",
+              "",
+              f"- **RC tag**: `{rc_tag}`",
+              f"- **Previous release**: `{prev_release}` ({prev_desc})",
+              f"- **Filtered diff size**: {filtered_total} lines",
+              f"- **Symbol index**: {len(symbol_index)} symbols currently documented; **0 new public symbols** in this diff",
+              "",
+              "### Outcome: 0 PRs opened (fast-path)",
+              "",
+              "The filtered diff contains no new `apply_filters` / `do_action` calls referencing undocumented symbols, no `register_rest_route(...)` registrations, and no `WP_CLI::add_command(...)` calls. Per the deterministic pre-agent fast-path, this RC introduces no public API surface and the Claude agent was not invoked.",
+              "",
+          ]
+          if top:
+              body.append("<details><summary>Top changed files</summary>")
+              body.append("")
+              body.append("```")
+              for path, count in top:
+                  body.append(f"  {path} | {count}")
+              body.append("```")
+              body.append("")
+              body.append("</details>")
+              body.append("")
+          body.append(f"_Fast-path decision — Claude agent skipped. Workflow run: {run_url}_")
+
+          out_path = os.path.join(bundle_dir, "fast-path-comment.md")
+          with open(out_path, "w") as f:
+              f.write("\n".join(body) + "\n")
+          print(f"No public surface detected — fast-path comment written to {out_path}")
+          print(f"  filtered_total={filtered_total}, symbols_known={len(symbol_index)}")
+          PY
+
+      - name: Post fast-path marker (no new public surface)
+        if: steps.bundle.outputs.any_content == 'true' && steps.detect.outputs.has_public_surface == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BUNDLE_DIR: ${{ github.workspace }}/${{ steps.bundle.outputs.bundle_dir }}
+        run: |
+          set -euo pipefail
+          gh issue comment '${{ matrix.item.tracking_issue }}' --body-file "${BUNDLE_DIR}/fast-path-comment.md"
+
+      - name: Invoke Claude agent
+        if: steps.bundle.outputs.any_content == 'true' && steps.detect.outputs.has_public_surface == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           PRODUCT: ${{ matrix.item.product }}
@@ -397,7 +544,7 @@ jobs:
             --model claude-sonnet-4-6
 
       - name: Ensure marker comment exists (safety net)
-        if: always() && steps.bundle.outputs.any_content == 'true'
+        if: always() && steps.bundle.outputs.any_content == 'true' && steps.detect.outputs.has_public_surface == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -275,7 +275,18 @@ jobs:
             rb="${bundle_dir}/${name}"
             mkdir -p "$rb"
             git -C "sources/${name}" diff "${{ matrix.item.prev_release }}..${{ matrix.item.rc_tag }}" > "${rb}/rc.diff.full"
+            # `-I<regex>` drops hunks whose *every* changed line matches at least one
+            # of the regexes. Used here to strip the per-RC version-string bumps
+            # (Version: header, WPSEO_VERSION define, "version": in package.json,
+            # CURRENT_RELEASE / MINIMUM_SUPPORTED constants) so the agent doesn't have
+            # to read them and dismiss them as noise each run. `rc.diff.full` keeps
+            # them as a cross-check.
             git -C "sources/${name}" diff "${{ matrix.item.prev_release }}..${{ matrix.item.rc_tag }}" \
+              -I' \* Version: ' \
+              -I'WPSEO_VERSION' \
+              -I'"version":' \
+              -I'CURRENT_RELEASE' \
+              -I'MINIMUM_SUPPORTED' \
               -- \
               ':(exclude)tests' \
               ':(exclude)**/__tests__' \

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -292,6 +292,9 @@ jobs:
               ':(exclude)tests' \
               ':(exclude)**/__tests__' \
               ':(exclude)**/__snapshots__' \
+              ':(exclude)**/*.test.*' \
+              ':(exclude)**/*.spec.*' \
+              ':(exclude)**/*.stories.*' \
               ':(exclude)**/*.lock' \
               ':(exclude)languages' \
               ':(exclude).github' \

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -290,8 +290,9 @@ jobs:
               -I'MINIMUM_SUPPORTED' \
               -- \
               ':(exclude)tests' \
-              ':(exclude)**/__tests__' \
-              ':(exclude)**/__snapshots__' \
+              ':(exclude)**/__tests__/**' \
+              ':(exclude)**/__snapshots__/**' \
+              ':(exclude)**/spec/**' \
               ':(exclude)**/*.test.*' \
               ':(exclude)**/*.spec.*' \
               ':(exclude)**/*.stories.*' \

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -1,7 +1,7 @@
 # .github/workflows/rc-docs-sync.yml
 #
 # Lives in: Yoast/developer
-# Purpose: once a day, check each opted-in product repo for RC tags we haven't
+# Purpose: every weekday, check each opted-in product repo for RC tags we haven't
 #          processed yet. For each new RC, ask a Claude agent whether the
 #          developer-portal docs need updates; if so, open one PR per affected
 #          feature area (per AGENT_MAP.md).
@@ -25,7 +25,7 @@ name: RC docs sync
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # daily at 06:00 UTC
+    - cron: '0 6 * * 1-5'  # 06:00 UTC, Monday through Friday only
   workflow_dispatch:
     inputs:
       product:

--- a/AGENT_MAP.md
+++ b/AGENT_MAP.md
@@ -173,8 +173,8 @@ No currently-listed product has more than one source repo. If one is ever added 
 ### `ai`
 - **Products**: wordpress-seo, wordpress-seo-premium
 - **Docs paths**: `docs/features/ai/**`
-- **Source paths** (wordpress-seo): `src/ai/**` (current convention — all new AI feature code lives here), `src/ai-*/**` (legacy, being migrated under `src/ai/`; safe to drop once the migration completes), `src/generators/ai*`, `src/integrations/ai*`
-- **Source paths** (wordpress-seo-premium): `src/ai/**`
+- **Source paths** (wordpress-seo): `src/ai/**` (current convention — all new AI feature code lives here), `src/ai-*/**` (legacy, being migrated under `src/ai/`; safe to drop once the migration completes), `src/generators/ai*`, `src/integrations/ai*`, `packages/js/src/ai-*/**` (frontend code for AI features lives in per-feature `ai-<slug>/` directories under the JS package; e.g. `ai-content-planner/`)
+- **Source paths** (wordpress-seo-premium): `src/ai/**`, `packages/js/src/ai-*/**`
 - **Symbol namespaces**: `wpseo_ai_*`
 - **Typical triggers**: new AI error code; new AI feature exposing a filter; change to request/retry behavior documented in `ai-errors.md`.
 


### PR DESCRIPTION
## Summary

Reduce unnecessary work by the RC docs-sync agent, based on patterns observed across the entire 27.6 RC cycle (RC1–RC8). Three original concerns from the proposal — fast-path, AGENT_MAP gap, version-bump noise — plus refinements discovered while validating locally.

## What changed

1. **Pre-agent fast-path** (`Detect new public surface in filtered diff` step). When the filtered diff has no new `register_rest_route(...)`, no new `WP_CLI::add_command(...)`, and every `apply_filters` / `do_action` symbol referenced in added lines is already in `symbol-index.txt`, the workflow posts the run-summary itself with the `rc-docs-sync:v1` marker and skips the Claude Code Action.
2. **Strip version-string bumps from `rc.diff.filtered`** via `git diff -I<regex>` for `Version:` header, `WPSEO_VERSION`, `"version":`, `"pluginVersion":`, `CURRENT_RELEASE`, `MINIMUM_SUPPORTED`.
3. **AGENT_MAP coverage for AI Content Planner JS** — add `packages/js/src/ai-*/**` to the `ai` area's source paths so the gap flagged in 4 consecutive RCs is no longer flagged each run.
4. **Fix pathspec semantics & add `spec/**`** — `:(exclude)**/__tests__` and `:(exclude)**/__snapshots__` only matched the directory entry itself, not its contents (latent bug — no `__tests__` in 27.6-cycle diffs so unobserved). Fixed both, plus added `**/spec/**` (the yoastseo JS package's `spec/` directory contains a 46,806-line `sampleVocabulary.json` fixture that was driving ~78% of the stable→RC diff size).
5. **Filename-suffix test exclusions** — `**/*.test.*`, `**/*.spec.*`, `**/*.stories.*` per the AGENT_MAP convention. Catches `packages/js/tests/*.test.js` that fell through the directory-based exclusions.
6. **Widen safety-net condition** — the earlier fast-path commit narrowed the safety-net to fire only on `has_public_surface == 'true'`, which would have left a missing marker if the new `detect` step itself crashed. Reverted to `any_content == 'true'`; the step body already self-deduplicates.
7. **Weekday-only schedule** — cron changed from `'0 6 * * *'` to `'0 6 * * 1-5'`. Weekend runs almost always find nothing; `workflow_dispatch` still works for urgent off-hours backfill.

## Measured impact (validated locally against the real `Yoast/wordpress-seo` repo at each tag)

**Filtered diff sizes — original vs. final:**

| Prev → RC | Original | Final | Reduction |
|---|---|---|---|
| 27.5 → 27.6-RC1 | 62,175 | 6,775 | 89% |
| 27.5 → 27.6-RC2 | 62,314 | 6,904 | 89% |
| RC1 → RC2 | 391 | 356 | 9% |
| RC2 → RC3 | 154 | 62 | 60% |
| RC3 → RC4 | 711 | 467 | 34% |
| RC4 → RC5 | 1,804 | 1,042 | 42% |
| RC5 → RC6 | 264 | 168 | 36% |
| RC6 → RC7 | 927 | 376 | 59% |
| RC7 → RC8 | 918 | 643 | 30% |

**Fast-path decisions — `has_public_surface` matches actual agent behavior in every case:**

| Prev → RC | Real-world | Fast-path verdict | Match |
|---|---|---|---|
| 27.5 → 27.6-RC1 | agent ran ($4.51, opened PR #393) | agent (2 new routes) | ✓ |
| 27.5 → 27.6-RC2 | agent ran ($2.10, 0 PRs) | agent (2 routes + new hook) | ✓ |
| RC2 → RC3 | agent ran ($0.89, 0 PRs) | **fast-path — skipped** | ✓ |
| RC3 → RC4 | agent ran ($1.08, 0 PRs) | **fast-path — skipped** | ✓ |
| RC4 → RC5 | agent ran ($1.30, 0 PRs) | **fast-path — skipped** | ✓ |
| RC5 → RC6 | infra fail (no agent output) | agent (new public filter `wpseo_enable_ai_content_planner_inline_banner`) | ✓ correct call |
| RC6 → RC7 | agent ran ($1.40, 0 PRs) | **fast-path — skipped** | ✓ |
| RC7 → RC8 | agent ran ($0.60, 0 PRs, route classified internal) | agent (1 new route) | ✓ |

Retroactive saving across RC3, RC4, RC5, RC7: **~$4.67 / 179 turns** without changing any outcome. Future stable→RC runs (e.g. when 27.7-RC1 is cut against 27.6 stable) will have ~7k filtered lines instead of ~62k for the agent to read.

## Risk and mitigation

The fast-path could miss "behavior-only" changes that don't introduce new symbols. The agent prompt already flags those as uncertain "Needs human verification" cases, and across 7 zero-PR runs none of them surfaced one. The fast-path comment includes a "Top changed files" details block so a maintainer sweeping the tracking issue can spot anomalies without reading the diff.

The weekday-only schedule introduces up to ~3 days of latency for an RC tagged late Friday (in the 27.6 cycle, RC4 was tagged Fri 2026-05-01 and would slip from Saturday to Monday under the new schedule). `workflow_dispatch` remains available for urgent backfill.

## Test plan

- [x] Workflow YAML parses (`yaml.safe_load`).
- [x] Embedded Python parses (`ast.parse`).
- [x] End-to-end local test against a real `Yoast/wordpress-seo` clone for all 9 historical RC-pair scenarios (`27.5→RC1`, `27.5→RC2`, `RC1→RC2`, `RC2→RC3`, …, `RC7→RC8`) — every `has_public_surface` decision matches the actual agent run's outcome.
- [x] Version-bump filtering verified file-by-file: `wp-seo.php` / `wp-seo-main.php` / `package.json` no longer appear in `rc.diff.filtered`.
- [x] Test/spec exclusions verified: `packages/yoastseo/spec/**/*.json` and `packages/js/tests/**/*.test.js` no longer appear.
- [ ] Optional smoke test on a real run via `workflow_dispatch` with `product=wordpress-seo rc_tag=27.6-RC4` (or any past RC) before/instead of waiting for the next 06:00 UTC schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)