### PR TITLE
rc-docs-sync: collapse multiple unprocessed RCs to the latest per run

### DIFF
--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -165,26 +165,34 @@ jobs:
                       continue
                   last_key = sort_key(processed_markers[-1])
                   rcs_to_process = sorted([t for t in rc_tags if sort_key(t) > last_key], key=sort_key)
-                  # Collapse multiple unprocessed RCs to just the latest. Earlier
-                  # RCs in the same sync run would otherwise fan out as separate
-                  # matrix entries and produce duplicate PRs (see GH run
-                  # 26561237947, which opened PRs #400 and #401 for the same
-                  # filter introduced in 27.8-RC1 and re-emitted in 27.8-RC2).
-                  # The latest RC's diff base is computed below as usual; the
-                  # skipped RCs get a "superseded" marker so the state machine
-                  # advances past them. Explicit per-RC backfill via
+                  # Within each base version, collapse to just the latest unprocessed
+                  # RC and mark earlier ones in that group as superseded — earlier RCs
+                  # in the same base would otherwise fan out as separate matrix
+                  # entries and produce duplicate PRs (see GH run 26561237947, which
+                  # opened #400 and #401 for the same filter introduced in 27.8-RC1
+                  # and re-emitted in 27.8-RC2). Collapsing is *per base version* so
+                  # if two cycles' RCs are simultaneously unprocessed (e.g. workflow
+                  # missed 27.8-RC1 and 27.9-RC1), each base still gets its own
+                  # queue entry diffed against its own previous-stable. Explicit
                   # workflow_dispatch with input_rc_tag bypasses this collapse.
                   if len(rcs_to_process) > 1:
-                      latest = rcs_to_process[-1]
-                      for skipped in rcs_to_process[:-1]:
-                          superseded_actions.append({
-                              "issue": tracking_issue,
-                              "product": slug,
-                              "rc_tag": skipped,
-                              "superseded_by": latest,
-                              "display_name": product["display_name"],
-                          })
-                      rcs_to_process = [latest]
+                      by_base = {}
+                      for rc in rcs_to_process:
+                          by_base.setdefault(base_version(rc), []).append(rc)
+                      collapsed = []
+                      for base, group in by_base.items():
+                          group_sorted = sorted(group, key=sort_key)
+                          latest_in_group = group_sorted[-1]
+                          for skipped in group_sorted[:-1]:
+                              superseded_actions.append({
+                                  "issue": tracking_issue,
+                                  "product": slug,
+                                  "rc_tag": skipped,
+                                  "superseded_by": latest_in_group,
+                                  "display_name": product["display_name"],
+                              })
+                          collapsed.append(latest_in_group)
+                      rcs_to_process = sorted(collapsed, key=sort_key)
 
               for rc_tag in rcs_to_process:
                   # Prefer the most recent already-processed RC of the same base version as

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -148,6 +148,9 @@ jobs:
               stable_tags = [t for t in all_tags if STABLE_RE.match(t)]
 
               processed_markers = fetch_processed_markers(tracking_issue, slug)
+              # Per-product state — must be initialized for every iteration of the
+              # outer loop, and used by both the dispatch and the scheduled paths.
+              superseded_by_latest = {}
 
               if input_rc_tag and input_product == slug:
                   if input_rc_tag not in rc_tags:
@@ -163,7 +166,14 @@ jobs:
                               "rc_tag": seed_rc, "display_name": product["display_name"],
                           })
                       continue
-                  last_key = sort_key(processed_markers[-1])
+                  # Use the max processed marker by sort_key, not the last in
+                  # document order. Superseded markers are posted *after* their
+                  # superseding RC's marker, so document order would mis-identify
+                  # an older (superseded) RC as the high-water mark and re-queue
+                  # an already-processed RC. Manual backfills via workflow_dispatch
+                  # (which can post markers for arbitrarily-old RCs) have the same
+                  # property.
+                  last_key = sort_key(max(processed_markers, key=sort_key))
                   rcs_to_process = sorted([t for t in rc_tags if sort_key(t) > last_key], key=sort_key)
                   # Within each base version, collapse to just the latest unprocessed
                   # RC and attach the skipped ones as `superseded_rcs` on that queue
@@ -178,7 +188,6 @@ jobs:
                   # 27.9-RC1), each base still gets its own queue entry diffed
                   # against its own previous-stable. Explicit workflow_dispatch
                   # with input_rc_tag bypasses this collapse.
-                  superseded_by_latest = {}
                   if len(rcs_to_process) > 1:
                       by_base = {}
                       for rc in rcs_to_process:

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -130,7 +130,7 @@ jobs:
 
           input_product = os.environ.get("INPUT_PRODUCT") or ""
           input_rc_tag = os.environ.get("INPUT_RC_TAG") or ""
-          queue, seed_actions, superseded_actions = [], [], []
+          queue, seed_actions = [], []
 
           products_to_sweep = [input_product] if input_product else list(PRODUCTS.keys())
           for slug in products_to_sweep:
@@ -166,15 +166,19 @@ jobs:
                   last_key = sort_key(processed_markers[-1])
                   rcs_to_process = sorted([t for t in rc_tags if sort_key(t) > last_key], key=sort_key)
                   # Within each base version, collapse to just the latest unprocessed
-                  # RC and mark earlier ones in that group as superseded — earlier RCs
-                  # in the same base would otherwise fan out as separate matrix
-                  # entries and produce duplicate PRs (see GH run 26561237947, which
-                  # opened #400 and #401 for the same filter introduced in 27.8-RC1
-                  # and re-emitted in 27.8-RC2). Collapsing is *per base version* so
-                  # if two cycles' RCs are simultaneously unprocessed (e.g. workflow
-                  # missed 27.8-RC1 and 27.9-RC1), each base still gets its own
-                  # queue entry diffed against its own previous-stable. Explicit
-                  # workflow_dispatch with input_rc_tag bypasses this collapse.
+                  # RC and attach the skipped ones as `superseded_rcs` on that queue
+                  # entry. The matrix step that processes the latest RC will post
+                  # the superseded markers itself, AFTER its own marker is in place
+                  # — that way a clone/bundle failure doesn't leave the tracking
+                  # issue with superseded markers that incorrectly advance state
+                  # past unprocessed RCs.
+                  #
+                  # Collapsing is *per base version*: if two cycles' RCs are
+                  # simultaneously unprocessed (e.g. workflow missed 27.8-RC1 and
+                  # 27.9-RC1), each base still gets its own queue entry diffed
+                  # against its own previous-stable. Explicit workflow_dispatch
+                  # with input_rc_tag bypasses this collapse.
+                  superseded_by_latest = {}
                   if len(rcs_to_process) > 1:
                       by_base = {}
                       for rc in rcs_to_process:
@@ -183,14 +187,7 @@ jobs:
                       for base, group in by_base.items():
                           group_sorted = sorted(group, key=sort_key)
                           latest_in_group = group_sorted[-1]
-                          for skipped in group_sorted[:-1]:
-                              superseded_actions.append({
-                                  "issue": tracking_issue,
-                                  "product": slug,
-                                  "rc_tag": skipped,
-                                  "superseded_by": latest_in_group,
-                                  "display_name": product["display_name"],
-                              })
+                          superseded_by_latest[latest_in_group] = group_sorted[:-1]
                           collapsed.append(latest_in_group)
                       rcs_to_process = sorted(collapsed, key=sort_key)
 
@@ -226,16 +223,16 @@ jobs:
                       "prev_release": prev,
                       "prev_kind": prev_kind,
                       "tracking_issue": tracking_issue,
+                      "superseded_rcs": superseded_by_latest.get(rc_tag, []),
                   })
 
-          print(json.dumps({"queue": queue, "seeds": seed_actions, "superseded": superseded_actions}))
+          print(json.dumps({"queue": queue, "seeds": seed_actions}))
           PY
           cat queue.json
           # Emit queue as compact JSON for matrix consumption.
           echo "queue_json=$(jq -c '.queue' queue.json)" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.queue | length' queue.json)" >> "$GITHUB_OUTPUT"
           echo "seed_count=$(jq '.seeds | length' queue.json)" >> "$GITHUB_OUTPUT"
-          echo "superseded_count=$(jq '.superseded | length' queue.json)" >> "$GITHUB_OUTPUT"
 
       - name: Seed first-run tracking issues
         if: steps.queue.outputs.seed_count != '0'
@@ -252,31 +249,6 @@ jobs:
             gh issue comment "$issue" --body "<!-- rc-docs-sync:v1 product=${product} rc_tag=${rc_tag} -->
 
           **First-run seed for ${display}** — RC tag \`${rc_tag}\` recorded as the baseline. No historical RCs will be processed automatically. To backfill a specific RC, use \`workflow_dispatch\` with \`product=${product}\` and the desired \`rc_tag\`."
-          done
-
-      - name: Mark superseded RCs (latest-only-per-run)
-        if: steps.queue.outputs.superseded_count != '0'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          jq -c '.superseded[]' queue.json | while read -r entry; do
-            issue=$(echo "$entry" | jq -r .issue)
-            product=$(echo "$entry" | jq -r .product)
-            rc_tag=$(echo "$entry" | jq -r .rc_tag)
-            superseded_by=$(echo "$entry" | jq -r .superseded_by)
-            display=$(echo "$entry" | jq -r .display_name)
-            base_version="${rc_tag%-RC*}"
-            # Idempotency: skip if a marker for this RC already exists.
-            if gh issue view "$issue" --json comments --jq '.comments[].body' \
-                | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${product}[[:space:]]+rc_tag=${rc_tag}[[:space:]]*-->"; then
-              echo "Marker for ${product} ${rc_tag} already exists; skipping superseded marker."
-              continue
-            fi
-            gh issue comment "$issue" --body "<!-- rc-docs-sync:v1 product=${product} rc_tag=${rc_tag} -->
-
-          **${display} ${base_version}** (RC \`${rc_tag}\`) — superseded by \`${superseded_by}\` in the same sync run. The later RC was processed against the same diff base, so any net public-surface changes are covered there. This RC was not individually processed."
           done
 
       - name: Note when queue is empty
@@ -687,3 +659,45 @@ jobs:
           Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
           Inspect the run logs and any PRs labeled \`rc/${rc_tag}\` to see what the agent produced before failing."
+
+      # Posts "superseded by X" markers for the RCs this matrix entry collapsed
+      # past. Gated on the latest RC's own marker actually being present — if
+      # clone or bundle failed before any marker for this RC was posted, the
+      # skipped RCs stay unmarked so the next run re-picks them up correctly
+      # (rather than being incorrectly used as `same_base_processed` diff bases).
+      - name: Mark RCs superseded by this entry
+        if: always() && steps.bundle.outputs.any_content != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          LATEST_RC_TAG: ${{ matrix.item.rc_tag }}
+          DISPLAY_NAME: ${{ matrix.item.display_name }}
+          PRODUCT: ${{ matrix.item.product }}
+          TRACKING_ISSUE: ${{ matrix.item.tracking_issue }}
+          SUPERSEDED_RCS: ${{ toJSON(matrix.item.superseded_rcs) }}
+        run: |
+          set -euo pipefail
+          # No-op when this entry didn't collapse anything.
+          if [ "$(echo "$SUPERSEDED_RCS" | jq 'length')" = "0" ]; then
+            exit 0
+          fi
+          # Refuse to post superseded markers unless the marker for this entry's
+          # latest RC is already on the tracking issue (placed by the no-op step,
+          # fast-path step, agent itself, or the safety-net step above).
+          if ! gh issue view "$TRACKING_ISSUE" --json comments --jq '.comments[].body' \
+              | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${PRODUCT}[[:space:]]+rc_tag=${LATEST_RC_TAG}[[:space:]]*-->"; then
+            echo "Latest RC ${LATEST_RC_TAG} has no marker yet; not posting superseded markers."
+            exit 0
+          fi
+          base_version="${LATEST_RC_TAG%-RC*}"
+          echo "$SUPERSEDED_RCS" | jq -r '.[]' | while read -r rc_tag; do
+            [ -z "$rc_tag" ] && continue
+            if gh issue view "$TRACKING_ISSUE" --json comments --jq '.comments[].body' \
+                | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${PRODUCT}[[:space:]]+rc_tag=${rc_tag}[[:space:]]*-->"; then
+              echo "Marker for ${rc_tag} already exists; skipping."
+              continue
+            fi
+            gh issue comment "$TRACKING_ISSUE" --body "<!-- rc-docs-sync:v1 product=${PRODUCT} rc_tag=${rc_tag} -->
+
+          **${DISPLAY_NAME} ${base_version}** (RC \`${rc_tag}\`) — superseded by \`${LATEST_RC_TAG}\` in the same sync run. The later RC was processed against the same diff base, so any net public-surface changes are covered there."
+          done

--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -130,7 +130,7 @@ jobs:
 
           input_product = os.environ.get("INPUT_PRODUCT") or ""
           input_rc_tag = os.environ.get("INPUT_RC_TAG") or ""
-          queue, seed_actions = [], []
+          queue, seed_actions, superseded_actions = [], [], []
 
           products_to_sweep = [input_product] if input_product else list(PRODUCTS.keys())
           for slug in products_to_sweep:
@@ -165,6 +165,26 @@ jobs:
                       continue
                   last_key = sort_key(processed_markers[-1])
                   rcs_to_process = sorted([t for t in rc_tags if sort_key(t) > last_key], key=sort_key)
+                  # Collapse multiple unprocessed RCs to just the latest. Earlier
+                  # RCs in the same sync run would otherwise fan out as separate
+                  # matrix entries and produce duplicate PRs (see GH run
+                  # 26561237947, which opened PRs #400 and #401 for the same
+                  # filter introduced in 27.8-RC1 and re-emitted in 27.8-RC2).
+                  # The latest RC's diff base is computed below as usual; the
+                  # skipped RCs get a "superseded" marker so the state machine
+                  # advances past them. Explicit per-RC backfill via
+                  # workflow_dispatch with input_rc_tag bypasses this collapse.
+                  if len(rcs_to_process) > 1:
+                      latest = rcs_to_process[-1]
+                      for skipped in rcs_to_process[:-1]:
+                          superseded_actions.append({
+                              "issue": tracking_issue,
+                              "product": slug,
+                              "rc_tag": skipped,
+                              "superseded_by": latest,
+                              "display_name": product["display_name"],
+                          })
+                      rcs_to_process = [latest]
 
               for rc_tag in rcs_to_process:
                   # Prefer the most recent already-processed RC of the same base version as
@@ -200,13 +220,14 @@ jobs:
                       "tracking_issue": tracking_issue,
                   })
 
-          print(json.dumps({"queue": queue, "seeds": seed_actions}))
+          print(json.dumps({"queue": queue, "seeds": seed_actions, "superseded": superseded_actions}))
           PY
           cat queue.json
           # Emit queue as compact JSON for matrix consumption.
           echo "queue_json=$(jq -c '.queue' queue.json)" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.queue | length' queue.json)" >> "$GITHUB_OUTPUT"
           echo "seed_count=$(jq '.seeds | length' queue.json)" >> "$GITHUB_OUTPUT"
+          echo "superseded_count=$(jq '.superseded | length' queue.json)" >> "$GITHUB_OUTPUT"
 
       - name: Seed first-run tracking issues
         if: steps.queue.outputs.seed_count != '0'
@@ -223,6 +244,31 @@ jobs:
             gh issue comment "$issue" --body "<!-- rc-docs-sync:v1 product=${product} rc_tag=${rc_tag} -->
 
           **First-run seed for ${display}** — RC tag \`${rc_tag}\` recorded as the baseline. No historical RCs will be processed automatically. To backfill a specific RC, use \`workflow_dispatch\` with \`product=${product}\` and the desired \`rc_tag\`."
+          done
+
+      - name: Mark superseded RCs (latest-only-per-run)
+        if: steps.queue.outputs.superseded_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          jq -c '.superseded[]' queue.json | while read -r entry; do
+            issue=$(echo "$entry" | jq -r .issue)
+            product=$(echo "$entry" | jq -r .product)
+            rc_tag=$(echo "$entry" | jq -r .rc_tag)
+            superseded_by=$(echo "$entry" | jq -r .superseded_by)
+            display=$(echo "$entry" | jq -r .display_name)
+            base_version="${rc_tag%-RC*}"
+            # Idempotency: skip if a marker for this RC already exists.
+            if gh issue view "$issue" --json comments --jq '.comments[].body' \
+                | grep -Eq "<!--[[:space:]]*rc-docs-sync:v1[[:space:]]+product=${product}[[:space:]]+rc_tag=${rc_tag}[[:space:]]*-->"; then
+              echo "Marker for ${product} ${rc_tag} already exists; skipping superseded marker."
+              continue
+            fi
+            gh issue comment "$issue" --body "<!-- rc-docs-sync:v1 product=${product} rc_tag=${rc_tag} -->
+
+          **${display} ${base_version}** (RC \`${rc_tag}\`) — superseded by \`${superseded_by}\` in the same sync run. The later RC was processed against the same diff base, so any net public-surface changes are covered there. This RC was not individually processed."
           done
 
       - name: Note when queue is empty


### PR DESCRIPTION
Run [26561237947](https://github.com/Yoast/developer/actions/runs/26561237947) produced duplicate PRs #400 and #401 because the resolver fanned out a matrix entry per unprocessed RC.

Fix: collapse multiple unprocessed RCs to just the latest *per base version* (so two cycles' RCs aren't accidentally merged). Each matrix entry carries a `superseded_rcs` list; the matrix step itself posts those superseded markers, gated on the latest RC's own marker being on the tracking issue first. If clone/bundle fails, no superseded markers are posted and the next run re-picks up the skipped RCs. `last_key` uses `max(processed_markers, key=sort_key)` so out-of-order markers (superseded or manual backfill) can't reset state. `workflow_dispatch` with explicit `rc_tag` bypasses collapse.

9 synthetic resolver scenarios cover bug case, mid-cycle, single-RC, empty, dispatch bypass, mixed bases, document-order-after-superseded, and backfilled-older-RC.