### PR TITLE
rc-docs-sync: fix jq precedence bug in 'Fetch recent open documentation PRs'

### DIFF
--- a/.github/workflows/rc-docs-sync.yml
+++ b/.github/workflows/rc-docs-sync.yml
@@ -374,7 +374,7 @@ jobs:
             --limit 50 \
             --json number,title,headRefName,updatedAt,body,files,labels \
             | jq '[ .[]
-                    | select((.files // []) | any(.path | startswith("docs/") or .path == "sidebars.js"))
+                    | select((.files // []) | any((.path | startswith("docs/")) or .path == "sidebars.js"))
                     | {number, title, headRefName, updatedAt,
                        files: [.files[].path],
                        body: .body[0:1500] }


### PR DESCRIPTION
Run [26742647973](https://github.com/Yoast/developer/actions/runs/26742647973) failed because the jq filter \`any(.path | startswith("docs/") or .path == "sidebars.js")\` parses as \`.path | (startswith("docs/") or .path == "sidebars.js")\` — the second \`.path\` indexes a string instead of the file object, crashing whenever an iterated file doesn't start with \`docs/\`. Latent until a non-\`docs/\` PR appeared in the search result (PR #402 today). Parenthesize the predicate so the second \`.path\` refers to the original file.

Side effect of today's failure: 27.8-RC3/RC4/RC5 each got a safety-net marker on issue #390 without any actual processing — those RCs are now marked "processed" but no docs work happened. Recovery is to delete those three marker comments so a subsequent run (after this fix + #402 land) re-picks them up.