### PR TITLE
Update Yoast Duplicate Post changelog for 4.7

### DIFF
--- a/changelogs/duplicate-post.md
+++ b/changelogs/duplicate-post.md
@@ -1,3 +1,24 @@
+## 4.7
+
+Release date: 2026-06-22
+
+#### Enhancements
+
+* Adds a link to the existing duplicate in the Rewrite & Republish admin notices, so you can open it directly instead of hunting for it in the post list. Props to [@johnbillion](https://github.com/johnbillion).
+
+#### Bugfixes
+
+* Fixes a bug where a published post could be overwritten by a user without permission to edit it, when that user scheduled a Rewrite & Republish copy of the post for future publication. Props to [@nacento](https://github.com/nacento).
+* Fixes a bug where a PHP deprecation notice appeared in the block editor, when a user opened a Rewrite & Republish copy of a post they were not allowed to edit.
+* Fixes a bug where the _Copy to a new draft_ and _Rewrite & Republish_ links broke the layout of the Classic Editor Publish meta box on WordPress 7.0.
+
+#### Other
+
+* Improves the security of the welcome notice dismissal by requiring a valid nonce and the `manage_options` capability.
+* Improves the security of the scheduled republish notice in the Classic editor by escaping the post title and permalink before output.
+* Sets the _WordPress tested up to_ version to 7.0.
+
+
 ## 4.6
 
 Release date: 2026-03-09


### PR DESCRIPTION
Fixes #

## Summary
Adds the Yoast Duplicate Post 4.7 changelog entry to `changelogs/duplicate-post.md`. Same content as the wp.org plugin page and `changelog.md` in `Yoast/duplicate-post`. This step used to happen automatically as part of the old Jenkins release task (`Update_Changelog_on_Yoast_developer` in `Yoast/yoast-ci-scripts`); it was lost in the migration to GitHub Actions and is now being filed manually.

## Relevant technical choices
None. Content-only change.

## Test instructions
This PR can be acceptance tested by following these steps:
1. Open the Cloudflare Pages preview build linked from this PR.
2. Navigate to the Yoast Duplicate Post changelog page.
3. Confirm the new "## 4.7" section appears at the top with release date 2026-06-22 and the same bullets shown in [the source changelog](https://github.com/Yoast/duplicate-post/blob/trunk/changelog.md).

## Quality assurance
* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [x] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.
