### PR TITLE
Remove Ryte from wp_get_environment_type() doc and list current non-production behavior

### DIFF
--- a/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
+++ b/docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md
@@ -44,4 +44,4 @@ Another feature of WordPress, Application Passwords is tied to the value returne
 
 ### On non-production environments
 
-On sites that are not live - `if ( wp_get_environment_type() !== 'production' )` - , several things are not necessary. Thus, in these cases, the plugin does not fetch Ryte data, does not execute the Ryte Site Health check, disables data tracking and disables search engine pinging about the XML sitemap.
+On sites that are not live - `if ( wp_get_environment_type() !== 'production' )` -, some of the plugin's features are unnecessary. In these cases, Yoast SEO does not build its indexables (the internal tables that store the SEO metadata for your content), does not show the notification that asks you to optimize your SEO data, and disables the tracking of usage data.


### PR DESCRIPTION
Fixes #413

## Summary
The "On non-production environments" section of the `wp_get_environment_type()` page listed behavior that no longer exists. Ryte was removed in Yoast SEO 19.6, so the plugin no longer fetches Ryte data or runs a Ryte Site Health check. Search engine pinging for the XML sitemap was deprecated in 22.0 (`WPSEO_Sitemaps_Admin::ping_search_engines()` is now a no-op), so it no longer happens on any environment.

This updates the section to describe what Yoast SEO actually skips on non-production sites today:

* it does not build its indexables;
* it does not show the notification that asks you to optimize your SEO data;
* it disables the tracking of usage data.

This was the only page in the docs that mentioned Ryte.

## Relevant technical choices
The three remaining behaviors are the ones gated behind `Environment_Helper::is_production_mode()` in `wordpress-seo`:

* `Indexable_Helper::should_index_indexables()` returns `false`, which stops indexables being saved (and also affects the `wpseo index` command, schema aggregation, and llms.txt content collection).
* `Indexing_Notification_Integration::should_show_notification()` returns `false`.
* `WPSEO_Tracking` bails out when not in production mode.

I left the existing `if ( wp_get_environment_type() !== 'production' )` example untouched, since that check is still accurate.

## Test instructions
This PR can be acceptance tested by following these steps:
1. Open `docs/customization/yoast-seo/wp-get-environment-type-in-yoast-seo.md` (or the built page) and read the "On non-production environments" section.
1. Confirm there is no mention of Ryte or of search engine sitemap pinging anywhere on the page.
1. Confirm the listed non-production behavior reads as: does not build indexables, does not show the optimize-SEO-data notification, and disables usage tracking.

## Quality assurance
* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.
