### PR TITLE
Prevent preloading of JS chunks on changelog routes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ export default {
 	title: "Yoast developer portal",
 	url: "https://developer.yoast.com",
 	baseUrl: "/",
+	clientModules: [ require.resolve("./src/clientModules/noChangelogPreload.js") ],
 
 	favicon: "img/favicon.png",
 	trailingSlash: true,

--- a/src/clientModules/noChangelogPreload.js
+++ b/src/clientModules/noChangelogPreload.js
@@ -1,0 +1,50 @@
+/**
+ * Prevents Docusaurus from preloading changelog route chunks on mouseover.
+ *
+ * Docusaurus's <Link> component calls window.docusaurus.preload() on
+ * onMouseEnter/onTouchStart, which eagerly loads ALL JS chunks for the
+ * target route. With 9 changelog products, each with many posts, this means
+ * hovering over a changelog link triggers a large number of chunk downloads.
+ *
+ * This patches preload (and prefetch) to be a no-op for changelog routes.
+ * Chunks are still loaded normally on actual navigation (click).
+ */
+
+if (typeof document !== 'undefined') {
+  /**
+   * Patches window.docusaurus — must be called after it's initialized.
+   */
+  function patch() {
+    if (!window.docusaurus) {
+      return;
+    }
+
+    const originalPreload = window.docusaurus.preload;
+    const originalPrefetch = window.docusaurus.prefetch;
+
+    function isChangelogRoute(path) {
+      return typeof path === 'string' && path.startsWith('/changelog/');
+    }
+
+    window.docusaurus = Object.freeze({
+      ...window.docusaurus,
+      preload(routePath) {
+        if (isChangelogRoute(routePath)) {
+          return Promise.resolve();
+        }
+        return originalPreload(routePath);
+      },
+      prefetch(routePath) {
+        if (isChangelogRoute(routePath)) {
+          return false;
+        }
+        return originalPrefetch(routePath);
+      },
+    });
+  }
+
+  // window.docusaurus may not exist yet when clientModules are evaluated
+  // (webpack static import hoisting). Defer with requestAnimationFrame so
+  // clientEntry.js has had a chance to set it up.
+  requestAnimationFrame(patch);
+}

--- a/src/clientModules/noChangelogPreload.js
+++ b/src/clientModules/noChangelogPreload.js
@@ -11,11 +11,16 @@
  */
 
 if (typeof document !== 'undefined') {
+  const MAX_ATTEMPTS = 60; // ~1s at 60fps
+
   /**
-   * Patches window.docusaurus — must be called after it's initialized.
+   * Patches window.docusaurus — retries until it's initialized.
    */
-  function patch() {
+  function patch(attempt = 0) {
     if (!window.docusaurus) {
+      if (attempt < MAX_ATTEMPTS) {
+        requestAnimationFrame(() => patch(attempt + 1));
+      }
       return;
     }
 
@@ -44,7 +49,7 @@ if (typeof document !== 'undefined') {
   }
 
   // window.docusaurus may not exist yet when clientModules are evaluated
-  // (webpack static import hoisting). Defer with requestAnimationFrame so
-  // clientEntry.js has had a chance to set it up.
-  requestAnimationFrame(patch);
+  // (webpack static import hoisting). Defer with requestAnimationFrame and
+  // retry until ready so clientEntry.js has had a chance to set it up.
+  requestAnimationFrame(() => patch());
 }


### PR DESCRIPTION
Fixes #

## Summary
<!-- What does this PR change/introduce? -->
Attempts to reduce request spam on developer.yoast.com by removing preload calls from changelog links. A mouseover on a product could generate up to 100 requests. Considering these pages are all text there was no considerable speed to be gained by preloading but the calls were all logged and clogging pipelines.

## Relevant technical choices
Technical choices that affect more than this issue:
Docusaurus doesn't seem to provide a less-roundabout way of doing this. So Qwen 🤖 came up with this solution. 

## Test instructions
This PR can be acceptance tested by following these steps:
1. Check if links to products on the changelog page still cause a flood of requests in the browser network tab.

## Quality assurance
* [x] Security - I have thought about any security implications this code might add.
* [x] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [x] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
