### PR TITLE
Reduce default changelog page size from 50 to 20

### DIFF
--- a/src/plugins/changelog/index.js
+++ b/src/plugins/changelog/index.js
@@ -104,7 +104,7 @@ async function ChangelogPlugin( context, options ) {
 		...options,
 		archiveBasePath: null,
 		showReadingTime: false,
-		postsPerPage: 50,
+		postsPerPage: 20,
 		blogSidebarCount: 10,
 		blogSidebarTitle: "Recent releases",
 		blogListComponent: "@theme/ChangelogList",


### PR DESCRIPTION
Fixes #

## Summary
<!-- What does this PR change/introduce? -->
Reduce the amount of changelog items per page to reduce prefetch javascript chunk loading on page load. Enhances changes in https://github.com/Yoast/developer/pull/417

## Relevant technical choices
Technical choices that affect more than this issue:

## Test instructions
This PR can be acceptance tested by following these steps:
1.
1.
1.

## Quality assurance
* [ ] Security - I have thought about any security implications this code might add.
* [ ] Performance - I have checked that this code doesn't impact performance (greatly).
* [ ] Caching - I have analyzed the caching methods that this code touches and have added instructions to deal with those.
* [ ] Tested - I have tested this code to the best of my abilities.
* [ ] Automated tests - I have added unit tests to verify the code works as intended.
* [ ] Testability - I have added unique ids to elements, so they can be located in automated testing.
* [ ] I have altered a filename.
    * [ ] I have adjusted the ID property accordingly and updated all internal links.
    * [ ] I have added the redirect to the `_redirects` file in the root of the project.

<!-- Note: Your PR can only be merged when the build succeeds, even by admins. 
For now, you can test this locally by running `yarn build`. -->
